### PR TITLE
Update Core for ReSpec 2.1.6

### DIFF
--- a/specs/core/attachments.html
+++ b/specs/core/attachments.html
@@ -11,6 +11,8 @@
   <script class='remove'>
     var fileName = "attachments.html";
     var respecConfig = {
+      // ===== Revision-specific settings =====
+
       specStatus: specConfig.status,
       revision: specConfig.revision,
       publishDate:  specConfig.publishDate,
@@ -23,9 +25,8 @@
       latestSpecVersion: "https://open-services.net/spec/core/latest",
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-      multiPartPrefix: "OSLC Core",
-      partNumber: 5,
-      // Other parts of multi-part spec
+      // ===== Links =====
+
       additionalArtifacts: [
         { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
         { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
@@ -63,17 +64,18 @@
         }
       },
 
-
-      // OSLC version number for the spec, and the revision level of the document within its stage
-      oslcVersion: "3.0",
-
-      // Only include h1 and h2 level in the TOC
-      maxTocLevel: 2,
-      conformanceLabelPrefix: "AT",
+      // ===== Spec settings =====
 
       shortName: "OSLC Attachments 3.0",
-
+      conformanceLabelPrefix: "AT",
       citationLabel: "OSLC-Attachments-3.0",
+      maxTocLevel: 2,
+
+      // TODO check if needs to be removed
+      multiPartPrefix: "OSLC Core",
+      partNumber: 5,
+      oslcVersion: "3.0",
+
       namespaces: [{
         href: "http://open-services.net/ns/core#",
         prefix: "oslc"
@@ -90,10 +92,12 @@
         companyURL: "http://www.ibm.com/"
       }],
 
+      // =====  Overall OSLC OP settings =====
+
       wg: "OASIS OSLC OP",
       wgShortName: "oslc-op",
-      wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
+      wgURI: "https://open-services.net/about/",
+
       chairs: [{
         name: "Jim Amsden",
         mailto: "jamsden@us.ibm.com",

--- a/specs/core/attachments.html
+++ b/specs/core/attachments.html
@@ -1,134 +1,112 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<meta charset='utf-8'/>
-<title>OSLC Core Version 3.0. Part 5: Attachments</title>
-<script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'></script>
-<script src="https://sspeiche.github.io/respec/js/n3-browser.min.js" class="remove" type="text/javascript"></script>
-<script class='remove'>
-  var respecConfig = {
-    // if you wish the publication date to be other than the last modification, set this
-    publishDate:  "2018-05-31",
-    specStatus : "PSPRD",
-    revision: "04",
+  <meta charset='utf-8' />
+  <title>OSLC Core Version 3.0. Part 5: Attachments</title>
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+    class='remove'></script>
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
+  <script class='remove'>
+    var fileName = "attachments.html";
+    var respecConfig = {
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      publishDate:  specConfig.publishDate,
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-    // OSLC version number for the spec, and the revision level of the document within its stage
-    oslcVersion: "3.0",
+      prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part5-attachments/oslc-core-v3.0-csprd03-part5-attachments.html",
+      thisVersion: thisBase + fileName,
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-    license : "cc-by-4",
+      multiPartPrefix: "OSLC Core",
+      partNumber: 5,
+      // Other parts of multi-part spec
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments (this document)", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+      ],
 
-    additionalLicenses : [{
-       licenseName : "Apache License 2.0",
-       licenseURI : "https://www.apache.org/licenses/LICENSE-2.0",
-     }],
+      relatedWork: [
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
+      ],
 
-    prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part5-attachments/oslc-core-v3.0-csprd03-part5-attachments.html",
-
-    // Only include h1 and h2 level in the TOC
-    maxTocLevel: 2,
-    conformanceLabelPrefix: "AT",
-    // noConformanceStyling: 1,
-    // noConformanceTable: 1,
-    // conformanceClauseStrength : 1,
-
-    // the specification's short name, as in http://www.w3.org/TR/short-name/
-    shortName:            "OSLC Attachments 3.0",
-
-    // the document's citation label
-    citationLabel: "OSLC-Attachments-3.0",
-
-
-    // if your specification has a subtitle that goes below the main
-    // formal title, define it here
-    // subtitle   :  "an excellent document",
-
-
-    // if the specification's copyright date is a range of years, specify
-    // the start date here:
-    // copyrightStart: "2005"
-
-    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-    // and its maturity status
-    // previousPublishDate:  "1977-03-15",
-    // previousMaturity:  "WD",
-
-    // if there a publicly available Editor's Draft, this is the link
-    // edDraftURI:           "http://berjon.com/",
-
-    // if this is a LCWD, uncomment and set the end of its review period
-    // lcEnd: "2009-08-05",
-
-    // editors, add as many as you like
-    // only "name" is required
-    chairs : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name : "Andrii Berezovskyi",
-      mailto: "andriib@kth.se",
-      company: "KTH",
-      companyURL: "https://www.kth.se/en"
-    } ],
-    editors : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    } ],
-
-    wg:           "OASIS OSLC OP",
-    wgShortName:  "oslc-op",
-    wgURI:        "https://github.com/oslc-op/oslc-specs",
-    wgPublicList: "oslc-op",
-
-    namespaces : [ {
-            href : "http://open-services.net/ns/core#",
-            prefix : "oslc"
-    } ],
-
-    multiPartPrefix: "OSLC Core",
-    partNumber: 5,
-    // Other parts of multi-part spec
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview", href: "oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments (this document)", href: "attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "core-vocab.html" }
-    ],
-
-    relatedWork : [
-      {title: "OSLC Core Version 3.0: Link Guidance", href: "https://raw.githack.com/oslc-op/oslc-specs/master/notes/link-guidance.html"}
-    ],
-
-    localBiblio:  {
-      "OSLCCore3": {
-          title:    "OSLC Core 3.0",
-          href:     "http://open-services.net/specifications/core/oslc-core.html",
-          authors:  ["Jim Amsden", "S. Speicher"],
-          status:   "Project Specification",
-          publisher:  "OASIS",
+      localBiblio: {
+        "OSLCCore3": {
+          title: "OSLC Core 3.0",
+          href: "http://open-services.net/specifications/core/oslc-core.html",
+          authors: ["Jim Amsden", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "OSLCCoreVocab": {
+          title: "OSLC Core Vocabulary",
+          href: "http://open-services.net/specifications/core/core-vocab.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "PURLMediaTypes": {
+          title: "Media Types",
+          href: "http://www.iana.org/assignments/media-types/media-types.xhtml",
+          authors: ["N. Freed", "M. Kucherawy", "M. Baker", "B. Hoehrmann"],
+          publisher: "IANA",
+        }
       },
-      "OSLCCoreVocab" : {
-          title : "OSLC Core Vocabulary",
-          href : "http://open-services.net/specifications/core/core-vocab.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher" ],
-          status:   "Project Specification",
-          publisher : "OASIS",
-      },
-      "PURLMediaTypes" : {
-           title : "Media Types",
-           href : "http://www.iana.org/assignments/media-types/media-types.xhtml",
-           authors : [ "N. Freed", "M. Kucherawy", "M. Baker", "B. Hoehrmann" ],
-           publisher : "IANA",
-      }
-    }
-  };
-</script>
+
+
+      // OSLC version number for the spec, and the revision level of the document within its stage
+      oslcVersion: "3.0",
+
+      // Only include h1 and h2 level in the TOC
+      maxTocLevel: 2,
+      conformanceLabelPrefix: "AT",
+
+      shortName: "OSLC Attachments 3.0",
+
+      citationLabel: "OSLC-Attachments-3.0",
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
+      license: "cc-by-4",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
+    };
+  </script>
 </head>
 <body>
 <section id="abstract">

--- a/specs/core/config.js
+++ b/specs/core/config.js
@@ -1,0 +1,23 @@
+var specConfig = {
+  status: "WD",
+  revision: "04",
+  publishDate: null,
+  previousPublishDate: "2018-05-31",
+  previousMaturity: "CSPRD",
+};
+
+var wdBase = "https://oslc-op.github.io/oslc-specs/specs/core/";
+var forceWdBase = false; // set to true if there are problems with the URIs
+var oasisBase = "https://docs.oasis-open-projects.org/oslc-op/core/v3.0/"
+
+var thisBase = wdBase;
+if (specConfig.status != "WD") {
+  thisBase = oasisBase + specConfig.status.toLowerCase() + specConfig.revision + "/";
+} else {
+  // if it's a WD, set
+  var scriptUri = document.currentScript.src;
+  var scriptBase = scriptUri.substr(0, scriptUri.lastIndexOf('/') + 1);
+  if (!forceWdBase) {
+    var thisBase = scriptBase;
+  }
+}

--- a/specs/core/core-vocab.html
+++ b/specs/core/core-vocab.html
@@ -87,6 +87,7 @@
       shortName: "oslc-core",
       subtitle: "Core Vocabulary",
       citationLabel: "OSLC-CoreVocab-3.0",
+      noConformanceTable: true,
       namespaces: [{
         href: "http://open-services.net/ns/core#",
         prefix: "oslc"

--- a/specs/core/core-vocab.html
+++ b/specs/core/core-vocab.html
@@ -1,136 +1,138 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<title>OSLC Core Version 3.0. Part 7: Vocabulary</title>
-<meta charset='utf-8' />
-<script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'></script>
-<script  class='remove' >
+  <title>OSLC Core Version 3.0. Part 7: Vocabulary</title>
+  <meta charset='utf-8' />
+  <script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async
+    class='remove'></script>
+  <script class='remove'>
     var respecConfig = {
-    // OSLC version number for the spec, and the revision level of the document within its stage
-    revision: "04",
-    specStatus : "PSD",
-    publishDate:  "2018-05-31",
+      // OSLC version number for the spec, and the revision level of the document within its stage
+      revision: "04",
+      specStatus: "PSD",
+      publishDate: "2018-05-31",
 
-    license : "cc-by-4",
+      license: "cc-by-4",
 
-    additionalLicenses : [{
-       licenseName : "Apache License 2.0",
-       licenseURI : "https://www.apache.org/licenses/LICENSE-2.0",
-     }],
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
 
-    edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/core-vocab.html",
-    thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html",
-    prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
-    latestVersion: "http://open-services.net/specifications/core/core-vocab.html",
+      edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/core-vocab.html",
+      thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html",
+      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+      latestVersion: "http://open-services.net/specifications/core/core-vocab.html",
 
-    // Only include h1 and h2 level
-    maxTocLevel: 2,
+      // Only include h1 and h2 level
+      maxTocLevel: 2,
 
-    // the specification's short name, as in http://oasis-open.org/
-    shortName : "oslc-core",
+      // the specification's short name, as in http://oasis-open.org/
+      shortName: "oslc-core",
 
-    // the document's citation label
-    citationLabel: "OSLC-CoreVocab-3.0",
-
-
-    // if your specification has a subtitle that goes below the main
-    // formal title, define it here
-    subtitle   :  "Core Vocabulary",
-
-    wg:           "OASIS OSLC OP",
-    wgShortName:  "oslc-op",
-    wgURI:        "https://github.com/oslc-op/oslc-specs",
-    wgPublicList: "oslc-op",
+      // the document's citation label
+      citationLabel: "OSLC-CoreVocab-3.0",
 
 
-    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-    // and its maturity status
-    // previousPublishDate:  "1977-03-15",
-    // previousMaturity:  "WD",
+      // if your specification has a subtitle that goes below the main
+      // formal title, define it here
+      subtitle: "Core Vocabulary",
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
 
 
-    // if this is a LCWD, uncomment and set the end of its review period
-    // lcEnd: "2009-08-05",
+      // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
+      // and its maturity status
+      // previousPublishDate:  "1977-03-15",
+      // previousMaturity:  "WD",
 
-    // chairs, 1 or many
-    chairs : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name : "Andrii Berezovskyi",
-      mailto: "andriib@kth.se",
-      company: "KTH",
-      companyURL: "https://www.kth.se/en"
-    } ],
-    editors : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    } ],
 
-    namespaces : [ {
-            href : "http://open-services.net/ns/core#",
-            prefix : "oslc"
-    } ],
+      // if this is a LCWD, uncomment and set the end of its review period
+      // lcEnd: "2009-08-05",
 
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
-    ],
+      // chairs, 1 or many
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
 
-    relatedWork : [
-         {title: "OSLC Core Version 3.0: Link Guidance", href: "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/supporting-docs/link-guidance.html"}
-    ],
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
 
-        localBiblio : {
-            "OSLCCore2" : {
-                title:    "OSLC Core 2.0",
-                href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification",
-                authors:  ["S. Speicher", "D. Johnson"],
-                status:   "Finalized",
-                publisher:  "http://open-services.net",
-            },
-            "OSLCCore3" : {
-                title : "OSLC Core 3.0",
-                href : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
-                authors : [ "Steve Speicher" ],
-                publisher : "OASIS",
-            },
-            "ResourceShapes" : {
-                title : "OSLC Resource Shape 3.0",
-                href : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part6-resource-shape.html",
-                authors : [ "Arthur Ryman", "Jim Amsden" ],
-                publisher : "OASIS",
-            },
-            "SysML" : {
-                title : "System Modeling Language",
-                href : "http://www.omg.org/spec/SysML/",
-                publisher : "OMG",
-            },
-            "LinkGuidance": {
-                title : "OSLC Link Guidance 3.0",
-                href : "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/supporting-docs/link-guidance.html",
-                authors : [ "Steve Speicher", "Jim Amsden" ],
-                publisher : "OASIS",
-            },
-          "SHACL" : {
-              title:    "Shapes Constraint Language (SHACL)",
-              href:     "https://w3c.github.io/data-shapes/shacl/",
-              authors:  ["Holger Knublauch", "Arthur Ryman"],
-              status:   "Draft",
-              publisher:  "http://www.w3.org/",
-          }
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
+      ],
+
+      relatedWork: [
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/supporting-docs/link-guidance.html" }
+      ],
+
+      localBiblio: {
+        "OSLCCore2": {
+          title: "OSLC Core 2.0",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCCore3": {
+          title: "OSLC Core 3.0",
+          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
+          authors: ["Steve Speicher"],
+          publisher: "OASIS",
+        },
+        "ResourceShapes": {
+          title: "OSLC Resource Shape 3.0",
+          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part6-resource-shape.html",
+          authors: ["Arthur Ryman", "Jim Amsden"],
+          publisher: "OASIS",
+        },
+        "SysML": {
+          title: "System Modeling Language",
+          href: "http://www.omg.org/spec/SysML/",
+          publisher: "OMG",
+        },
+        "LinkGuidance": {
+          title: "OSLC Link Guidance 3.0",
+          href: "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/supporting-docs/link-guidance.html",
+          authors: ["Steve Speicher", "Jim Amsden"],
+          publisher: "OASIS",
+        },
+        "SHACL": {
+          title: "Shapes Constraint Language (SHACL)",
+          href: "https://w3c.github.io/data-shapes/shacl/",
+          authors: ["Holger Knublauch", "Arthur Ryman"],
+          status: "Draft",
+          publisher: "http://www.w3.org/",
         }
+      }
     };
-</script>
+  </script>
 </head>
 <body>
 

--- a/specs/core/core-vocab.html
+++ b/specs/core/core-vocab.html
@@ -4,92 +4,41 @@
 <head>
   <title>OSLC Core Version 3.0. Part 7: Vocabulary</title>
   <meta charset='utf-8' />
-  <script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
     class='remove'></script>
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
+    var fileName = "core-vocab.html";
     var respecConfig = {
-      // OSLC version number for the spec, and the revision level of the document within its stage
-      revision: "04",
-      specStatus: "PSD",
-      publishDate: "2018-05-31",
+      // ===== Revision-specific settings =====
 
-      license: "cc-by-4",
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      publishDate:  specConfig.publishDate,
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-      additionalLicenses: [{
-        licenseName: "Apache License 2.0",
-        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
-      }],
+      // ===== Links =====
 
-      edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/core-vocab.html",
-      thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html",
-      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
-      latestVersion: "http://open-services.net/specifications/core/core-vocab.html",
-
-      // Only include h1 and h2 level
-      maxTocLevel: 2,
-
-      // the specification's short name, as in http://oasis-open.org/
-      shortName: "oslc-core",
-
-      // the document's citation label
-      citationLabel: "OSLC-CoreVocab-3.0",
-
-
-      // if your specification has a subtitle that goes below the main
-      // formal title, define it here
-      subtitle: "Core Vocabulary",
-
-      wg: "OASIS OSLC OP",
-      wgShortName: "oslc-op",
-      wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
-
-
-      // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-      // and its maturity status
-      // previousPublishDate:  "1977-03-15",
-      // previousMaturity:  "WD",
-
-
-      // if this is a LCWD, uncomment and set the end of its review period
-      // lcEnd: "2009-08-05",
-
-      // chairs, 1 or many
-      chairs: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }, {
-        name: "Andrii Berezovskyi",
-        mailto: "andriib@kth.se",
-        company: "KTH",
-        companyURL: "https://www.kth.se/en"
-      }],
-      editors: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }],
-
-      namespaces: [{
-        href: "http://open-services.net/ns/core#",
-        prefix: "oslc"
-      }],
+      prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+      thisVersion: thisBase + fileName,
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary (this document)", href: thisBase + "core-vocab.html" }
       ],
 
       relatedWork: [
-        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/supporting-docs/link-guidance.html" }
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
       ],
 
       localBiblio: {
@@ -130,10 +79,51 @@
           status: "Draft",
           publisher: "http://www.w3.org/",
         }
-      }
+      },
+
+      // ===== Spec settings =====
+
+      maxTocLevel: 2,
+      shortName: "oslc-core",
+      subtitle: "Core Vocabulary",
+      citationLabel: "OSLC-CoreVocab-3.0",
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
+      license: "cc-by-4",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+
+      // =====  Overall OSLC OP settings =====
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
     };
   </script>
 </head>
+
 <body>
 
     <section id='abstract'>Core Vocabulary defines the OSLC Core RDF vocabulary terms and resources, that have broad applicability across various domains.</section>

--- a/specs/core/dialogs.html
+++ b/specs/core/dialogs.html
@@ -1,123 +1,125 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<meta charset='utf-8'/>
-<title>OSLC Core Version 3.0. Part 4: Delegated Dialogs</title>
-<script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'></script>
-<script class='removx'>
-  var respecConfig = {
-    specStatus : "PSD",
-    // OSLC version number for the spec, and the revision level of the document within its stage
-    revision: "04",
-    // if you wish the publication date to be other than the last modification, set this
-    publishDate:  "2018-05-31",
-    
-    license : "cc-by-4",
+  <meta charset='utf-8' />
+  <title>OSLC Core Version 3.0. Part 4: Delegated Dialogs</title>
+  <script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async
+    class='remove'></script>
+  <script class='removx'>
+    var respecConfig = {
+      specStatus: "PSD",
+      // OSLC version number for the spec, and the revision level of the document within its stage
+      revision: "04",
+      // if you wish the publication date to be other than the last modification, set this
+      publishDate: "2018-05-31",
 
-    additionalLicenses : [{
-       licenseName : "Apache License 2.0",
-       licenseURI : "https://www.apache.org/licenses/LICENSE-2.0",
-     }],
+      license: "cc-by-4",
 
-    edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/dialogs.html",
-    thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html",
-    prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part4-delegated-dialogs/oslc-core-v3.0-csprd03-part4-delegated-dialogs.html",
-    latestVersion: "http://open-services.net/specifications/core/dialogs.html",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
 
-    // the specification's short name, as in http://www.w3.org/TR/short-name/
-    shortName:            "OSLC Delegated Dialogs 3.0",
-    conformanceLabelPrefix: "DD",
+      edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/dialogs.html",
+      thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html",
+      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part4-delegated-dialogs/oslc-core-v3.0-csprd03-part4-delegated-dialogs.html",
+      latestVersion: "http://open-services.net/specifications/core/dialogs.html",
 
-    // the document's citation label
-    citationLabel: "OSLC-Dialogs-3.0",
+      // the specification's short name, as in http://www.w3.org/TR/short-name/
+      shortName: "OSLC Delegated Dialogs 3.0",
+      conformanceLabelPrefix: "DD",
 
-
-    // Only include h1 and h2 level in the TOC
-    maxTocLevel: 2,
-
-    // if your specification has a subtitle that goes below the main
-    // formal title, define it here
-    // subtitle   :  "an excellent document",
+      // the document's citation label
+      citationLabel: "OSLC-Dialogs-3.0",
 
 
-    wg:           "OASIS OSLC OP",
-    wgShortName:  "oslc-op",
-    wgURI:        "https://github.com/oslc-op/oslc-specs",
-    wgPublicList: "oslc-op",
+      // Only include h1 and h2 level in the TOC
+      maxTocLevel: 2,
+
+      // if your specification has a subtitle that goes below the main
+      // formal title, define it here
+      // subtitle   :  "an excellent document",
 
 
-    // editors, add as many as you like
-    // only "name" is required
-      chairs : [ {
-        name : "Jim Amsden",
-        mailto : "jamsden@us.ibm.com",
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
+
+
+      // editors, add as many as you like
+      // only "name" is required
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
         company: "IBM",
         companyURL: "http://www.ibm.com/"
       }, {
-        name : "Andrii Berezovskyi",
+        name: "Andrii Berezovskyi",
         mailto: "andriib@kth.se",
         company: "KTH",
         companyURL: "https://www.kth.se/en"
-      } ],
-      editors : [ {
-        name : "Jim Amsden",
-        mailto : "jamsden@us.ibm.com",
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
         company: "IBM",
         companyURL: "http://www.ibm.com/"
-      } ],
+      }],
 
-   namespaces : [ {
-            href : "http://open-services.net/ns/core#",
-            prefix : "oslc"
-    } ],
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
 
-    // Other parts of multi-part spec
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
-    ],
+      // Other parts of multi-part spec
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
+      ],
 
-    relatedWork : [
-        {title: "OSLC Core Version 3.0: Link Guidance", href: "https://raw.githack.com/oslc-op/oslc-specs/master/notes/link-guidance.html"}
-    ],
+      relatedWork: [
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
+      ],
 
-    localBiblio:  {
-        "OSLCCore3" : {
-          title:    "OSLC Core 3.0",
-          href:     "http://open-services.net/specifications/core/oslc-core.html",
-          authors:  ["Jim Amsden", "S. Speicher"],
-          status:   "Project Specification",
-          publisher:  "OASIS",
+      localBiblio: {
+        "OSLCCore3": {
+          title: "OSLC Core 3.0",
+          href: "http://open-services.net/specifications/core/oslc-core.html",
+          authors: ["Jim Amsden", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
         },
-        "OSLCCoreVocab" : {
-          title : "OSLC Core Vocabulary",
-          href : "http://open-services.net/specifications/core/core-vocab.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher" ],
-          status:   "Project Specification",
-          publisher : "OASIS",
+        "OSLCCoreVocab": {
+          title: "OSLC Core Vocabulary",
+          href: "http://open-services.net/specifications/core/core-vocab.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
         },
         "OSLCPreview30": {
-          title:    "OSLC Resource Preview 3.0",
-          href:     "http://open-services.net/specifications/core/resource-preview.html",
-          authors:  ["Jim Amsden", "S. Speicher"],
-          status:   "Project Specification",
-          publisher:  "OASIS",
+          title: "OSLC Resource Preview 3.0",
+          href: "http://open-services.net/specifications/core/resource-preview.html",
+          authors: ["Jim Amsden", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
         },
         "OSLCCore2": {
-            title:    "OSLC Core 2.0",
-            href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification",
-            authors:  ["S. Speicher", "D. Johnson"],
-            status:   "Finalized",
-            publisher:  "http://open-services.net"
+          title: "OSLC Core 2.0",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net"
         }
-    }
-  };
-</script>
+      }
+    };
+  </script>
 </head>
 
 <body>

--- a/specs/core/dialogs.html
+++ b/specs/core/dialogs.html
@@ -4,84 +4,36 @@
 <head>
   <meta charset='utf-8' />
   <title>OSLC Core Version 3.0. Part 4: Delegated Dialogs</title>
-  <script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
     class='remove'></script>
-  <script class='removx'>
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
+  <script class='remove'>
+    var fileName = "dialogs.html";
     var respecConfig = {
-      specStatus: "PSD",
-      // OSLC version number for the spec, and the revision level of the document within its stage
-      revision: "04",
-      // if you wish the publication date to be other than the last modification, set this
-      publishDate: "2018-05-31",
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      publishDate:  specConfig.publishDate,
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-      license: "cc-by-4",
-
-      additionalLicenses: [{
-        licenseName: "Apache License 2.0",
-        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
-      }],
-
-      edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/dialogs.html",
-      thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html",
-      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part4-delegated-dialogs/oslc-core-v3.0-csprd03-part4-delegated-dialogs.html",
-      latestVersion: "http://open-services.net/specifications/core/dialogs.html",
-
-      // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName: "OSLC Delegated Dialogs 3.0",
-      conformanceLabelPrefix: "DD",
-
-      // the document's citation label
-      citationLabel: "OSLC-Dialogs-3.0",
+      prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part4-delegated-dialogs/oslc-core-v3.0-csprd03-part4-delegated-dialogs.html",
+      thisVersion: thisBase + fileName,
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
 
-      // Only include h1 and h2 level in the TOC
-      maxTocLevel: 2,
-
-      // if your specification has a subtitle that goes below the main
-      // formal title, define it here
-      // subtitle   :  "an excellent document",
-
-
-      wg: "OASIS OSLC OP",
-      wgShortName: "oslc-op",
-      wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
-
-
-      // editors, add as many as you like
-      // only "name" is required
-      chairs: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }, {
-        name: "Andrii Berezovskyi",
-        mailto: "andriib@kth.se",
-        company: "KTH",
-        companyURL: "https://www.kth.se/en"
-      }],
-      editors: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }],
-
-      namespaces: [{
-        href: "http://open-services.net/ns/core#",
-        prefix: "oslc"
-      }],
 
       // Other parts of multi-part spec
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs (this document)", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
       ],
 
       relatedWork: [
@@ -117,7 +69,45 @@
           status: "Finalized",
           publisher: "http://open-services.net"
         }
-      }
+      },
+
+
+
+      shortName: "OSLC Delegated Dialogs 3.0",
+      conformanceLabelPrefix: "DD",
+      citationLabel: "OSLC-Dialogs-3.0",
+      maxTocLevel: 2,
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
+      license: "cc-by-4",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
     };
   </script>
 </head>

--- a/specs/core/dialogs.html
+++ b/specs/core/dialogs.html
@@ -11,6 +11,8 @@
   <script class='remove'>
     var fileName = "dialogs.html";
     var respecConfig = {
+      // ===== Revision-specific settings =====
+
       specStatus: specConfig.status,
       revision: specConfig.revision,
       publishDate:  specConfig.publishDate,
@@ -23,9 +25,8 @@
       latestSpecVersion: "https://open-services.net/spec/core/latest",
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
+      // ===== Links =====
 
-
-      // Other parts of multi-part spec
       additionalArtifacts: [
         { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
         { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
@@ -71,7 +72,7 @@
         }
       },
 
-
+      // ===== Spec settings =====
 
       shortName: "OSLC Delegated Dialogs 3.0",
       conformanceLabelPrefix: "DD",
@@ -93,10 +94,11 @@
         companyURL: "http://www.ibm.com/"
       }],
 
+      // =====  Overall OSLC OP settings =====
+
       wg: "OASIS OSLC OP",
       wgShortName: "oslc-op",
       wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
       chairs: [{
         name: "Jim Amsden",
         mailto: "jamsden@us.ibm.com",

--- a/specs/core/discovery.html
+++ b/specs/core/discovery.html
@@ -11,11 +11,15 @@
   <script class='remove'>
     var fileName = "discovery.html";
     var respecConfig = {
+      // ===== Revision-specific settings =====
+
       specStatus: specConfig.status,
       revision: specConfig.revision,
       publishDate: specConfig.publishDate,
       previousPublishDate: specConfig.previousPublishDate,
       previousMaturity: specConfig.previousMaturity,
+
+      // ===== Links =====
 
       thisVersion: thisBase + fileName,
       prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part2-discovery/oslc-core-v3.0-csprd03-part2-discovery.html",
@@ -36,7 +40,6 @@
       relatedWork: [
         { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
       ],
-
 
       localBiblio: {
         "OSLCCore2": {
@@ -102,14 +105,34 @@
         }
       },
 
+      // ===== Spec settings =====
 
       shortName: "oslc-discovery",
       conformanceLabelPrefix: "DIS",
       citationLabel: "OSLC-Discovery-3.0",
+      maxTocLevel: 2,
+      oslcVersion: "3.0",
       namespaces: [{
         href: "http://open-services.net/ns/core#",
         prefix: "oslc"
       }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
+      license: "cc-by-4",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+
+      // =====  Overall OSLC OP settings =====
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://open-services.net/about/",
 
       chairs: [{
         name: "Jim Amsden",
@@ -122,32 +145,6 @@
         company: "KTH",
         companyURL: "https://www.kth.se/en"
       }],
-      editors: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }],
-
-      license: "cc-by-4",
-
-      additionalLicenses: [{
-        licenseName: "Apache License 2.0",
-        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
-      }],
-
-      // Only include h1 and h2 level in the TOC
-      maxTocLevel: 2,
-
-      // OSLC version number for the spec, and the revision level of the document within its stage
-      oslcVersion: "3.0",
-
-      // includePermalinks: true,
-
-      wg: "OASIS OSLC OP",
-      wgShortName: "oslc-op",
-      wgURI: "https://open-services.net/about/",
-      wgPublicList: "oslc-op",
     };
   </script>
 </head>

--- a/specs/core/discovery.html
+++ b/specs/core/discovery.html
@@ -1,160 +1,157 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<title>OSLC Core Version 3.0. Part 2: Discovery</title>
-<meta charset='utf-8'>
-<script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'></script>
-<script class='remove'>
-  var respecConfig = {
-    specStatus : "PSD",
-    revision: "04",
-    publishDate:  "2018-05-31",
+  <title>OSLC Core Version 3.0. Part 2: Discovery</title>
+  <meta charset='utf-8'>
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+    class='remove'></script>
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
+  <script class='remove'>
+    var fileName = "discovery.html";
+    var respecConfig = {
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      publishDate: specConfig.publishDate,
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-    license : "cc-by-4",
+      thisVersion: thisBase + fileName,
+      prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part2-discovery/oslc-core-v3.0-csprd03-part2-discovery.html",
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-    additionalLicenses : [{
-       licenseName : "Apache License 2.0",
-       licenseURI : "https://www.apache.org/licenses/LICENSE-2.0",
-     }],
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery (this document)", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+      ],
 
-    // Only include h1 and h2 level in the TOC
-    maxTocLevel: 2,
-    shortName : "oslc-discovery",
-    conformanceLabelPrefix: "DIS",
-
-    // the document's citation label
-    citationLabel: "OSLC-Discovery-3.0",
-
-    // if there a publicly available Editor's Draft, this is the link
-    edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/discovery.html",
-    thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html",
-    prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part2-discovery/oslc-core-v3.0-csprd03-part2-discovery.html",
-    latestVersion: "http://open-services.net/specifications/core/discovery.html",
-
-    // OSLC version number for the spec, and the revision level of the document within its stage
-    oslcVersion: "3.0",
-
-    // if you wish the publication date to be other than the last modification, set this
-    // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
-    // and its maturity status
-    // previousPublishDate:  "1977-03-15",
-    // previousMaturity:  "WD",
-
-    // if this is a LCWD, uncomment and set the end of its review period
-    // lcEnd: "2009-08-05",
-
-    // includePermalinks: true,
-
-    wg:           "OASIS OSLC OP",
-    wgShortName:  "oslc-op",
-    wgURI:        "https://github.com/oslc-op/oslc-specs",
-    wgPublicList: "oslc-op",
-
-    chairs : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name : "Andrii Berezovskyi",
-      mailto: "andriib@kth.se",
-      company: "KTH",
-      companyURL: "https://www.kth.se/en"
-    } ],
-    editors : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    } ],
-
-    namespaces : [ {
-            href : "http://open-services.net/ns/core#",
-            prefix : "oslc"
-    } ],
-
-    // Other parts of multi-part spec
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
-    ],
-
-    relatedWork : [
-      {title: "OSLC Core Version 3.0: Link Guidance", href: "https://raw.githack.com/oslc-op/oslc-specs/master/notes/link-guidance.html"}
-    ],
+      relatedWork: [
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
+      ],
 
 
-    localBiblio : {
-      "OSLCCore2" : {
-          title:    "OSLC Core 2.0",
-          href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "OSLCQuery" : {
-          title:    "OSLC Query Version 3.0",
-          href : "http://open-services.net/specifications/query/oslc-query.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher", "David Honey" ],
-          status:   "Public Review Draft Project Specification",
-          publisher : "OASIS",
-      },
-      "OSLCSPR" : {
-          title:    "OSLC Core 2.0 Service Provider Resources",
-          href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification#Service_Provider_Resources",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "OSLCSPV": {
-          title:    "OSLC Core 2.0 Selective Property Values",
-          href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification#Selective_Property_Values",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-        "OSLCCore3" : {
-          title:    "OSLC Core 3.0",
-          href:     "http://open-services.net/specifications/core/oslc-core.html",
-          authors:  ["Jim Amsden", "S. Speicher"],
-          status:   "Project Specification",
-          publisher:  "OASIS",
+      localBiblio: {
+        "OSLCCore2": {
+          title: "OSLC Core 2.0",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
         },
-      "OSLCCoreVocab" : {
-          title : "OSLC Core Vocabulary",
-          href : "http://open-services.net/specifications/core/core-vocab.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher" ],
-          status:   "Project Specification",
-          publisher : "OASIS",
-      },
-        "ResourcePreview" : {
-          title : "OSLC Resource Preview 3.0",
-          href:     "http://open-services.net/specifications/core/resource-preview.html",
-          authors : [ "Samuel Padgett", "Steve Speicher", "Jim Amsden" ],
-          status:   "Project Specification",
-          publisher : "OASIS",
+        "OSLCQuery": {
+          title: "OSLC Query Version 3.0",
+          href: "http://open-services.net/specifications/query/oslc-query.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher", "David Honey"],
+          status: "Public Review Draft Project Specification",
+          publisher: "OASIS",
         },
-        "Dialogs" : {
-            title : "OSLC Delegated Dialogs 3.0",
-            href:     "http://open-services.net/specifications/core/dialogs.html",
-            authors : [ "Samuel Padgett", "Steve Speicher" ],
-            status:   "Project Specification",
-            publisher : "OASIS",
+        "OSLCSPR": {
+          title: "OSLC Core 2.0 Service Provider Resources",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification#Service_Provider_Resources",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
         },
-        "OpenIDConnect" : {
-            title : "OpenID Connect",
-            href : "http://openid.net/connect/",
-            publisher : "openid.net",
+        "OSLCSPV": {
+          title: "OSLC Core 2.0 Selective Property Values",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification#Selective_Property_Values",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCCore3": {
+          title: "OSLC Core 3.0",
+          href: "http://open-services.net/specifications/core/oslc-core.html",
+          authors: ["Jim Amsden", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "OSLCCoreVocab": {
+          title: "OSLC Core Vocabulary",
+          href: "http://open-services.net/specifications/core/core-vocab.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "ResourcePreview": {
+          title: "OSLC Resource Preview 3.0",
+          href: "http://open-services.net/specifications/core/resource-preview.html",
+          authors: ["Samuel Padgett", "Steve Speicher", "Jim Amsden"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "Dialogs": {
+          title: "OSLC Delegated Dialogs 3.0",
+          href: "http://open-services.net/specifications/core/dialogs.html",
+          authors: ["Samuel Padgett", "Steve Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "OpenIDConnect": {
+          title: "OpenID Connect",
+          href: "http://openid.net/connect/",
+          publisher: "openid.net",
         }
-      }
-  };
-</script>
+      },
+
+
+      shortName: "oslc-discovery",
+      conformanceLabelPrefix: "DIS",
+      citationLabel: "OSLC-Discovery-3.0",
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
+
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
+
+      license: "cc-by-4",
+
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+
+      // Only include h1 and h2 level in the TOC
+      maxTocLevel: 2,
+
+      // OSLC version number for the spec, and the revision level of the document within its stage
+      oslcVersion: "3.0",
+
+      // includePermalinks: true,
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://open-services.net/about/",
+      wgPublicList: "oslc-op",
+    };
+  </script>
 </head>
+
 <body>
 
     <section id='abstract'>This document outlines a common approach for HTTP/LDP-based servers to be able to    publish their RESTful API capabilities and how clients discover and use them.</section>

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -1,189 +1,158 @@
 <!DOCTYPE html>
 <html xmlns='http://www.w3.org/1999/xhtml'>
 <head>
-<meta charset='utf-8' />
-<title>OSLC Core Version 3.0. Part 1: Overview</title>
-<script
-  src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js'
-  async class='remove'></script>
-<script class='remove'>
-  var respecConfig = {
+  <meta charset='utf-8' />
+  <title>OSLC Core Version 3.0. Part 1: Overview</title>
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+    class='remove'></script>
+    <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
+  <script class='remove'>
+    var fileName = "oslc-core.html";
 
-    // === The following settings are mandatory for every spec ===
+    var respecConfig = {
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      // publishDate:  "2019-08-08",
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-    // Specification status:
-    //        WD      Working Draft
-    //        PSD     Project Specification Draft
-    //        PS      Project Specification
-    //        COS     Candidate OASIS Standard
-    //        OS      OASIS Standard
-    //        Errata  Approved Errata
-    //        PND     Project Note Draft
-    //        PN      Project Note
-    specStatus : "PSD",
-    shortName : "oslc-core",
-    conformanceLabelPrefix: "CORE",
-    label: "3.0-psd-04",
-    citationLabel: "OSLC-Core-3.0-Part1",
+      thisVersion: thisBase + fileName,
+      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-    // Any of the following URIs may be set if you want to override the defaults
-    prevLabel: "3.0-cs-01",
-    //edDraftURI : "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/specs/oslc-core.html",
-    //thisVersion : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
-    //prevVersion : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/cs01/part1-overview/oslc-core-v3.0-cs01-part1-overview.html",
-    //latestVersion : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
 
-    // === The following settings are optional
+      // Other parts of multi-part spec
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview (this document)", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+      ],
 
-    // Only include h1 and h2 levels in the TOC (this is the default)
-    // maxTocLevel: 2,
+      relatedWork: [
+        {
+          title: "OSLC Core Version 3.0: Link Guidance",
+          href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html",
+          status: "Work in progress. Current draft",
+        }],
 
-    // if your specification has a subtitle that goes below the main
-    // formal title, define it here
-    // subtitle:  "an excellent document",
-
-    // if you wish the publication date to be other than the last modification, set this
-    // this value is ignored if the status is WD, when the last modify time is always shown
-    publishDate:  "2018-05-31",
-
-    // if the specification's copyright date is a range of years, specify
-    // the start date here:
-    // copyrightStart: "2005"
-    
-    // Set these if you do not want the defaults shown below:
-    //wg:           "OASIS Open Services for Lifecycle Integration (OSLC) Open Project",
-    //wgShortName:  "oslc-op",
-    //wgURI:        "https://github.com/oslc-op/oslc-specs",
-    //wgPublicList: "oslc-op",
-    
-
-    // chairs and editors, add as many as you like, but you should have at least one chair or editor
-    // only "name" is required
-    chairs : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name : "Andrii Berezovskyi",
-      mailto: "andriib@kth.se",
-      company: "KTH",
-      companyURL: "https://www.kth.se/en"
-    } ],
-    editors : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    } ],
-
-    // The namespaces defined by this spec - not the namespaces used
-    namespaces : [ {
-            href : "http://open-services.net/ns/core#",
-            prefix : "oslc"
-    } ],
-
-    // Other parts of multi-part spec
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
-    ],
-
-    relatedWork : [
-      {title: "OSLC Core Version 3.0: Link Guidance",
-       href: "https://raw.githack.com/oslc-op/oslc-specs/master/notes/link-guidance.html",
-       status: "Work in progress. Current draft",
-    }],
-
-    localBiblio : {
-      "OSLCCore2" : {
-          title:    "OSLC Core 2.0",
-          href:     "https://open-services.net/bin/view/Main/OslcCoreSpecification",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
+      localBiblio: {
+        "OSLCCore2": {
+          title: "OSLC Core 2.0",
+          href: "https://open-services.net/bin/view/Main/OslcCoreSpecification",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCQuery3": {
+          title: "OSLC Query Version 3.0",
+          href: "http://open-services.net/specifications/query/oslc-query.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher", "David Honey"],
+          status: "Public Review Draft Project Specification",
+          publisher: "OASIS",
+        },
+        "OSLCTRS3": {
+          title: "OSLC Tracked Resource Set Version 3.0",
+          href: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/trs/tracked-resource-set.html",
+          authors: ["Nick Crossley, Axel Reichwein"],
+          status: "Draft",
+          publisher: "OASIS",
+        },
+        "OSLCCCM1": {
+          title: "OSLC Configuration Management 1.0",
+          href: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/config/oslc-config-mgt.html",
+          authors: ["Nick Crossley"],
+          status: "Draft",
+          publisher: "OASIS",
+        },
+        "OSLCSPR": {
+          title: "OSLC Core 2.0 Service Provider Resources",
+          href: "https://open-services.net/bin/view/Main/OslcCoreSpecification#Service_Provider_Resources",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCSPV": {
+          title: "OSLC Core 2.0 Selective Property Values",
+          href: "https://open-services.net/bin/view/Main/OslcCoreSpecification#Selective_Property_Values",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCPaging": {
+          title: "OSLC Core 2.0 Resource Paging",
+          href: "https://open-services.net/bin/view/Main/OslcCoreSpecification#Resource_Paging",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "LDPPaging": {
+          title: "Linked Data Platform Paging 1.0",
+          href: "https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp-paging.html",
+          authors: ["S. Speicher", "J. Arwe", "A. Malhotra"],
+          status: "Working Group Note",
+          publisher: "http://www.w3c.org",
+        },
+        "OSLCShapes": {
+          title: "OSLC Resource Shape 3.0",
+          href: "http://open-services.net/specifications/core/resource-shape.html",
+          authors: ["Arthur Ryman", "Jim Amsden"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "SHACL": {
+          title: "Shapes Constraint Language (SHACL)",
+          href: "https://w3c.github.io/data-shapes/shacl/",
+          authors: ["Holger Knublauch", "Arthur Ryman"],
+          status: "Draft",
+          publisher: "http://www.w3.org/",
+        },
+        "OpenIDConnect": {
+          title: "OpenID Connect",
+          href: "http://openid.net/connect/",
+          publisher: "openid.net",
+        },
+        "LDBestPractices": {
+          title: "Linked Data Best Practices",
+          href: "https://jazz.net/wiki/bin/view/LinkedData/BestPractices",
+          publisher: "jazz.net",
+        }
       },
-      "OSLCQuery3" : {
-          title:    "OSLC Query Version 3.0",
-          href : "http://open-services.net/specifications/query/oslc-query.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher", "David Honey" ],
-          status:   "Public Review Draft Project Specification",
-          publisher : "OASIS",
-      },
-      "OSLCTRS3" : {
-          title:    "OSLC Tracked Resource Set Version 3.0",
-          href:     "https://raw.githack.com/oslc-op/oslc-specs/master/specs/trs/tracked-resource-set.html",
-          authors:  ["Nick Crossley, Axel Reichwein"],
-          status:   "Draft",
-          publisher:  "OASIS",
-      },
-      "OSLCCCM1" : {
-          title:    "OSLC Configuration Management 1.0",
-          href:     "https://raw.githack.com/oslc-op/oslc-specs/master/specs/config/oslc-config-mgt.html",
-          authors:  ["Nick Crossley"],
-          status:   "Draft",
-          publisher:  "OASIS",
-      },
-      "OSLCSPR" : {
-          title:    "OSLC Core 2.0 Service Provider Resources",
-          href:     "https://open-services.net/bin/view/Main/OslcCoreSpecification#Service_Provider_Resources",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "OSLCSPV": {
-          title:    "OSLC Core 2.0 Selective Property Values",
-          href:     "https://open-services.net/bin/view/Main/OslcCoreSpecification#Selective_Property_Values",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "OSLCPaging": {
-          title:    "OSLC Core 2.0 Resource Paging",
-          href:     "https://open-services.net/bin/view/Main/OslcCoreSpecification#Resource_Paging",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "LDPPaging": {
-          title:    "Linked Data Platform Paging 1.0",
-          href:     "https://dvcs.w3.org/hg/ldpwg/raw-file/default/ldp-paging.html",
-          authors:  ["S. Speicher", "J. Arwe", "A. Malhotra"],
-          status:   "Working Group Note",
-          publisher:  "http://www.w3c.org",
-      },
-      "OSLCShapes": {
-              title : "OSLC Resource Shape 3.0",
-              href : "http://open-services.net/specifications/core/resource-shape.html",
-              authors : [ "Arthur Ryman", "Jim Amsden" ],
-              status:   "Project Specification",
-              publisher : "OASIS",
-      },
-      "SHACL" : {
-          title:    "Shapes Constraint Language (SHACL)",
-          href:     "https://w3c.github.io/data-shapes/shacl/",
-          authors:  ["Holger Knublauch", "Arthur Ryman"],
-          status:   "Draft",
-          publisher:  "http://www.w3.org/",
-      },
-      "OpenIDConnect" : {
-          title : "OpenID Connect",
-          href : "http://openid.net/connect/",
-          publisher : "openid.net",
-      },
-     "LDBestPractices": {
-          title : "Linked Data Best Practices",
-          href : "https://jazz.net/wiki/bin/view/LinkedData/BestPractices",
-          publisher : "jazz.net",
-      }
-    }
-  };
-</script>
+
+
+      shortName: "oslc-core",
+      conformanceLabelPrefix: "CORE",
+      citationLabel: "OSLC-Core-3.0-Part1",
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
+
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "https://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "https://www.ibm.com/"
+      }],
+    };
+  </script>
 </head>
 <body>
 

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -10,11 +10,15 @@
   <script class='remove'>
     var fileName = "oslc-core.html";
     var respecConfig = {
+      // ===== Revision-specific settings =====
+
       specStatus: specConfig.status,
       revision: specConfig.revision,
       publishDate:  specConfig.publishDate,
       previousPublishDate: specConfig.previousPublishDate,
       previousMaturity: specConfig.previousMaturity,
+
+      // ===== Links =====
 
       prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
       thisVersion: thisBase + fileName,
@@ -22,8 +26,6 @@
       latestSpecVersion: "https://open-services.net/spec/core/latest",
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-
-      // Other parts of multi-part spec
       additionalArtifacts: [
         { title: "OSLC Core Version 3.0. Part 1: Overview (this document)", href: thisBase + "oslc-core.html" },
         { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
@@ -124,6 +126,7 @@
         }
       },
 
+      // ===== Spec settings =====
 
       shortName: "oslc-core",
       conformanceLabelPrefix: "CORE",
@@ -132,13 +135,23 @@
         href: "http://open-services.net/ns/core#",
         prefix: "oslc"
       }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "https://www.ibm.com/"
+      }],
       license: "cc-by-4",
       additionalLicenses: [{
         licenseName: "Apache License 2.0",
         licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
       }],
 
+      // =====  Overall OSLC OP settings =====
 
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://open-services.net/about/",
       chairs: [{
         name: "Jim Amsden",
         mailto: "jamsden@us.ibm.com",
@@ -149,12 +162,6 @@
         mailto: "andriib@kth.se",
         company: "KTH",
         companyURL: "https://www.kth.se/"
-      }],
-      editors: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "https://www.ibm.com/"
       }],
     };
   </script>

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -132,6 +132,12 @@
         href: "http://open-services.net/ns/core#",
         prefix: "oslc"
       }],
+      license: "cc-by-4",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+
 
       chairs: [{
         name: "Jim Amsden",

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -6,19 +6,18 @@
   <script src='./config.js' class='remove'></script>
   <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
     class='remove'></script>
-    <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
     var fileName = "oslc-core.html";
-
     var respecConfig = {
       specStatus: specConfig.status,
       revision: specConfig.revision,
-      // publishDate:  "2019-08-08",
+      publishDate:  specConfig.publishDate,
       previousPublishDate: specConfig.previousPublishDate,
       previousMaturity: specConfig.previousMaturity,
 
-      thisVersion: thisBase + fileName,
       prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+      thisVersion: thisBase + fileName,
       latestVersion: oasisBase + fileName,
       latestSpecVersion: "https://open-services.net/spec/core/latest",
       edDraftURI: "https://open-services.net/spec/core/latest-draft",

--- a/specs/core/resource-preview.html
+++ b/specs/core/resource-preview.html
@@ -1,117 +1,125 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<meta charset='utf-8'/>
-<title>OSLC Core Version 3.0. Part 3: Resource Preview</title>
-<script    src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'></script>
-<script class='remove'>
-  var respecConfig = {
-    specStatus : "PSD",
-    revision: "04",
-    publishDate:  "2018-05-31",
+  <meta charset='utf-8' />
+  <title>OSLC Core Version 3.0. Part 3: Resource Preview</title>
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+    class='remove'></script>
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
+  <script class='remove'>
+    var fileName = "resource-preview.html";
+    var respecConfig = {
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      publishDate: specConfig.publishDate,
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-    license : "cc-by-4",
-
-    additionalLicenses : [{
-       licenseName : "Apache License 2.0",
-       licenseURI : "https://www.apache.org/licenses/LICENSE-2.0",
-     }],
-    shortName: "resource-preview",
-    conformanceLabelPrefix: "RP",
-
-    // the document's citation label
-    citationLabel: "OSLC-ResourcePreview-3.0",
-
-
-    edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/resource-preview.html",
-    thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html",
-    prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part3-resource-preview/oslc-core-v3.0-csprd03-part3-resource-preview.html",
-    latestVersion: "http://open-services.net/specifications/core/resource-preview.html",
-
-    // if your specification has a subtitle that goes below the main
-    // formal title, define it here
-    // subtitle   :  "Committee Specification Draft 01",
+      thisVersion: thisBase + fileName,
+      prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part3-resource-preview/oslc-core-v3.0-csprd03-part3-resource-preview.html",
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
 
-    // includePermalinks: true,
-    wg:           "OASIS OSLC OP",
-    wgShortName:  "oslc-op",
-    wgURI:        "https://github.com/oslc-op/oslc-specs",
-    wgPublicList: "oslc-op",
 
-    chairs : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name : "Andrii Berezovskyi",
-      mailto: "andriib@kth.se",
-      company: "KTH",
-      companyURL: "https://www.kth.se/en"
-    } ],
-    editors : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    } ],
+      // Other parts of multi-part spec
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview (this document)", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+      ],
 
-    maxTocLevel: 2,
-
-    // Namespaces defined by this spec
-    namespaces : [
-      { href: "http://open-services.net/ns/core#", prefix: "oslc-core"}
-    ],
-
-    // Other parts of multi-part spec
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
-    ],
-
-    relatedWork : [
-        {title: "OSLC Core Version 3.0: Link Guidance", href: "https://tools.oasis-open.org/version-control/svn/oslc-core/trunk/supporting-docs/link-guidance.html"}
-    ],
+      relatedWork: [
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
+      ],
 
 
-    localBiblio:  {
-        "OSLCCore3" : {
-            title : "OSLC Core 3.0",
-            href : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
-            authors : [ "Steve Speicher" ],
-            publisher : "OASIS",
+      localBiblio: {
+        "OSLCCore3": {
+          title: "OSLC Core 3.0",
+          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
+          authors: ["Steve Speicher"],
+          publisher: "OASIS",
         },
         "OSLCUIPreview20": {
-            title:    "OSLC Core 2.0 - UI Preview",
-            href:     "http://open-services.net/bin/view/Main/OslcCoreUiPreview",
-            authors:  [ "S. Bosworth" ],
-            status:   "Finalized",
-            publisher:  "http://open-services.net"
+          title: "OSLC Core 2.0 - UI Preview",
+          href: "http://open-services.net/bin/view/Main/OslcCoreUiPreview",
+          authors: ["S. Bosworth"],
+          status: "Finalized",
+          publisher: "http://open-services.net"
         },
-        "OSLCCoreVocab" : {
-                title : "OSLC Core Vocabulary",
-                href : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part7-core-vocabulary.html",
-                authors : [ "Jim Amsden", "S. Padgett", "S. Speicher" ],
-                status:   "Working Draft",
-                publisher : "OASIS",
+        "OSLCCoreVocab": {
+          title: "OSLC Core Vocabulary",
+          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part7-core-vocabulary.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
+          status: "Working Draft",
+          publisher: "OASIS",
         },
         "JSONSchema": {
-            title:    "JSON Schema",
-            href:     "http://tools.ietf.org/html/draft-zyp-json-schema-04",
-            authors:  [ "F. Galiegue", "K. Zyp" ],
-            status:   "Informational",
-            publisher:  "https://www.ietf.org"
+          title: "JSON Schema",
+          href: "http://tools.ietf.org/html/draft-zyp-json-schema-04",
+          authors: ["F. Galiegue", "K. Zyp"],
+          status: "Informational",
+          publisher: "https://www.ietf.org"
         }
-    },
-  };
-</script>
+      },
+
+
+
+      license: "cc-by-4",
+
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+      shortName: "resource-preview",
+      conformanceLabelPrefix: "RP",
+
+      // the document's citation label
+      citationLabel: "OSLC-ResourcePreview-3.0",
+
+
+      // includePermalinks: true,
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
+
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }],
+
+      maxTocLevel: 2,
+
+      // Namespaces defined by this spec
+      namespaces: [
+        { href: "http://open-services.net/ns/core#", prefix: "oslc-core" }
+      ],
+    };
+  </script>
 </head>
+
 <body>
 
 <section id="abstract">Resource Preview defines a technique to get a minimal HTML representation of a

--- a/specs/core/resource-preview.html
+++ b/specs/core/resource-preview.html
@@ -11,6 +11,8 @@
   <script class='remove'>
     var fileName = "resource-preview.html";
     var respecConfig = {
+      // ===== Revision-specific settings =====
+
       specStatus: specConfig.status,
       revision: specConfig.revision,
       publishDate: specConfig.publishDate,
@@ -23,9 +25,8 @@
       latestSpecVersion: "https://open-services.net/spec/core/latest",
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
+      // ===== Links =====
 
-
-      // Other parts of multi-part spec
       additionalArtifacts: [
         { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
         { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
@@ -72,50 +73,44 @@
       },
 
 
+      // ===== Spec settings =====
 
+      shortName: "resource-preview",
+      conformanceLabelPrefix: "RP",
+      citationLabel: "OSLC-ResourcePreview-3.0",
+      maxTocLevel: 2,
+      namespaces: [
+        { href: "http://open-services.net/ns/core#", prefix: "oslc-core" }
+      ],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "https://www.ibm.com/"
+      }],
       license: "cc-by-4",
-
       additionalLicenses: [{
         licenseName: "Apache License 2.0",
         licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
       }],
-      shortName: "resource-preview",
-      conformanceLabelPrefix: "RP",
 
-      // the document's citation label
-      citationLabel: "OSLC-ResourcePreview-3.0",
+      // =====  Overall OSLC OP settings =====
 
-
-      // includePermalinks: true,
       wg: "OASIS OSLC OP",
       wgShortName: "oslc-op",
-      wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
+      wgURI: "https://open-services.net/about/",
 
       chairs: [{
         name: "Jim Amsden",
         mailto: "jamsden@us.ibm.com",
         company: "IBM",
-        companyURL: "http://www.ibm.com/"
+        companyURL: "https://www.ibm.com/"
       }, {
         name: "Andrii Berezovskyi",
         mailto: "andriib@kth.se",
         company: "KTH",
-        companyURL: "https://www.kth.se/en"
+        companyURL: "https://www.kth.se/"
       }],
-      editors: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }],
-
-      maxTocLevel: 2,
-
-      // Namespaces defined by this spec
-      namespaces: [
-        { href: "http://open-services.net/ns/core#", prefix: "oslc-core" }
-      ],
     };
   </script>
 </head>

--- a/specs/core/resource-shape.html
+++ b/specs/core/resource-shape.html
@@ -1,213 +1,215 @@
 <!DOCTYPE html>
 <html>
+
 <head>
-<title>OSLC Core Version 3.0. Part 6: Resource Shape</title>
-<meta charset='utf-8'>
-<script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove' type="text/javascript"></script>
-<script class='remove'>
-  var respecConfig = {
-    specStatus : "PSD",
-    revision: "03",
-    publishDate:  "2018-05-31",
+  <title>OSLC Core Version 3.0. Part 6: Resource Shape</title>
+  <meta charset='utf-8'>
+  <script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'
+    type="text/javascript"></script>
+  <script class='remove'>
+    var respecConfig = {
+      specStatus: "PSD",
+      revision: "03",
+      publishDate: "2018-05-31",
 
-    license : "cc-by-4",
+      license: "cc-by-4",
 
-    additionalLicenses : [{
-       licenseName : "Apache License 2.0",
-       licenseURI : "https://www.apache.org/licenses/LICENSE-2.0",
-     }],
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
 
-    // if there a publicly available Editor's Draft, this is the link
-    edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/resource-shape.html",
-    thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html",
-    prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
-    latestVersion: "http://open-services.net/specifications/core/resource-shape.html",
+      // if there a publicly available Editor's Draft, this is the link
+      edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/resource-shape.html",
+      thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html",
+      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+      latestVersion: "http://open-services.net/specifications/core/resource-shape.html",
 
-    // Only include h1 and h2 level
-    maxTocLevel: 2,
+      // Only include h1 and h2 level
+      maxTocLevel: 2,
 
-    shortName : "resource-shape",
-    conformanceLabelPrefix: "RS",
-    // the document's citation label
-    citationLabel: "OSLC-Shapes-3.0",
-
-
-    // if your specification has a subtitle that goes below the main
-    // formal title, define it here
-    // subtitle   :  "Committee Specification Draft 01",
+      shortName: "resource-shape",
+      conformanceLabelPrefix: "RS",
+      // the document's citation label
+      citationLabel: "OSLC-Shapes-3.0",
 
 
-    wg:           "OASIS OSLC OP",
-    wgShortName:  "oslc-op",
-    wgURI:        "https://github.com/oslc-op/oslc-specs",
-    wgPublicList: "oslc-op",
+      // if your specification has a subtitle that goes below the main
+      // formal title, define it here
+      // subtitle   :  "Committee Specification Draft 01",
 
-    chairs : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name : "Andrii Berezovskyi",
-      mailto: "andriib@kth.se",
-      company: "KTH",
-      companyURL: "https://www.kth.se/en"
-    } ],
-    editors : [ {
-      name : "Jim Amsden",
-      mailto : "jamsden@us.ibm.com",
-      company: "IBM",
-      companyURL: "http://www.ibm.com/"
-    }, {
-      name: "Arthur Ryman",
-      mailto : "arthur.ryman@gmail.com",
-      company: "Ryerson University",
-      companyURL: "http://www.ryerson.ca/"
-    } ],
 
-    namespaces : [ {
-            href : "http://open-services.net/ns/core#",
-            prefix : "oslc"
-    } ],
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
 
-    // Other parts of multi-part spec
-    additionalArtifacts : [
-      { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-      { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-      { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-      { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-      { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-      { title: "OSLC Core Version 3.0. Part 6: Resource Shape (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-      { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
-    ],
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/en"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "http://www.ibm.com/"
+      }, {
+        name: "Arthur Ryman",
+        mailto: "arthur.ryman@gmail.com",
+        company: "Ryerson University",
+        companyURL: "http://www.ryerson.ca/"
+      }],
 
-    relatedWork : [
-      {title: "OSLC Core Version 3.0: Link Guidance", href: "https://raw.githack.com/oslc-op/oslc-specs/master/notes/link-guidance.html"}
-    ],
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
 
-    localBiblio : {
-      "JSONSchema" : {
-          title:    "JSON Schema",
-          href:     "http://json-schema.org/",
-          status:   "Draft",
-          publisher:  "http://json-schema.org/",
-      },
-      "SHACL" : {
-          title:    "Shapes Constraint Language (SHACL)",
-          href:     "https://w3c.github.io/data-shapes/shacl/",
-          authors:  ["Holger Knublauch", "Arthur Ryman"],
-          status:   "Draft",
-          publisher:  "http://www.w3.org/",
-      },
-      "OSLCCore2" : {
-          title:    "OSLC Core 2.0",
-          href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "OSLCQuery" : {
-          title:    "OSLC Query Version 3.0",
-          href : "http://open-services.net/specifications/query/oslc-query.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher", "David Honey" ],
-          status:   "Public Review Draft Project Specification",
-          publisher : "OASIS",
-      },
-      "OSLCSPR" : {
-          title:    "OSLC Core 2.0 Service Provider Resources",
-          href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification#Service_Provider_Resources",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-      "OSLCSPV": {
-          title:    "OSLC Core 2.0 Selective Property Values",
-          href:     "http://open-services.net/bin/view/Main/OslcCoreSpecification#Selective_Property_Values",
-          authors:  ["S. Speicher", "D. Johnson"],
-          status:   "Finalized",
-          publisher:  "http://open-services.net",
-      },
-        "OSLCCore3" : {
-            title : "OSLC Core 3.0",
-            href : "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
-            authors : [ "Steve Speicher" ],
-            publisher : "OASIS",
+      // Other parts of multi-part spec
+      additionalArtifacts: [
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
+      ],
+
+      relatedWork: [
+        { title: "OSLC Core Version 3.0: Link Guidance", href: "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html" }
+      ],
+
+      localBiblio: {
+        "JSONSchema": {
+          title: "JSON Schema",
+          href: "http://json-schema.org/",
+          status: "Draft",
+          publisher: "http://json-schema.org/",
         },
-      "OSLCCoreVocab" : {
-          title : "OSLC Core Vocabulary",
-          href : "http://open-services.net/specifications/core/core-vocab.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher" ],
-          status:   "Project Specification",
-          publisher : "OASIS",
-      },
-        "ResourcePreview" : {
-          title:    "OSLC Resource Preview 3.0",
-          href:     "http://open-services.net/specifications/core/resource-preview.html",
-          authors:  ["Jim Amsden", "S. Speicher"],
-          status:   "Project Specification",
-          publisher:  "OASIS",
+        "SHACL": {
+          title: "Shapes Constraint Language (SHACL)",
+          href: "https://w3c.github.io/data-shapes/shacl/",
+          authors: ["Holger Knublauch", "Arthur Ryman"],
+          status: "Draft",
+          publisher: "http://www.w3.org/",
         },
-        "Dialogs" : {
-            title : "OSLC Delegated Dialogs 3.0",
-            href:     "http://open-services.net/specifications/core/dialogs.html",
-            authors : [ "Samuel Padgett", "Steve Speicher" ],
-            status:   "Project Specification",
-            publisher : "OASIS",
+        "OSLCCore2": {
+          title: "OSLC Core 2.0",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
         },
-      "RDFVAL": {
-          title:    "W3C RDF Validation Workshop",
-          href:     "http://www.w3.org/2012/12/rdf-val/",
-          publisher:  "W3C",
-      },
-      "RWLD": {
-          title:    "Read-Write Linked Data",
-          href:     "http://www.w3.org/DesignIssues/ReadWriteLinkedData.html",
-          authors:  ["Tim Berners-Lee"],
-          publisher:  "W3C",
-      },
-      "LDDI": {
-          title:    "Linked Data Design Issues",
-          href:     "http://www.w3.org/DesignIssues/LinkedData.html",
-          authors:  ["Tim Berners-Lee"],
-          publisher:  "W3C",
-      },
-      "TURTLE": {
-          title:    "Turtle - Terse RDF Triple Language",
-          href:     "http://www.w3.org/TR/turtle/",
-          authors:  ["Tim Berners-Lee", "David Beckett", "Eric Prud'hommeaux", "Gavin Carothers"],
-          publisher:  "W3C",
-      },
-      "REST": {
-          title:    "Representational State Transfer (REST)",
-          href:     "http://www.ics.uci.edu/%7Efielding/pubs/dissertation/rest_arch_style.htm",
-          authors:  ["Roy Thomas Fielding"],
-          publisher:  "University of California",
-      },
-      "LDOW2013": {
-          title:    "OSLC Resource Shape: A language for defining constraints on Linked Data",
-          href:     "http://events.linkeddata.org/ldow2013/papers/ldow2013-paper-02.pdf",
-          authors:  ["Arthur Ryman", "Arnaud Le Hors", "Steve Speicher"],
-      },
-      "LDINT": {
-          title:    "Linked Data Interfaces: Define REST API contracts for RDF resource representations",
-          href:     "http://www.ibm.com/developerworks/rational/library/linked-data-oslc-resource-shapes/",
-          authors:  ["Arthur Ryman"],
-          publisher:  "IBM",
-      },
-      "ShapesRDFVAL": {
-          title:    "OSLC Resource Shape: A Linked Data Constraint Language",
-          href:     "http://www.w3.org/2001/sw/wiki/images/b/b7/RDFVal_Fokuoe_Ryman.pdf",
-          authors:  ["Achille Fokoue", "Arthur Ryman"],
-          publisher:  "W3C",
-      },
-        "OpenIDConnect" : {
-            title : "OpenID Connect",
-            href : "http://openid.net/connect/",
-            publisher : "openid.net",
+        "OSLCQuery": {
+          title: "OSLC Query Version 3.0",
+          href: "http://open-services.net/specifications/query/oslc-query.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher", "David Honey"],
+          status: "Public Review Draft Project Specification",
+          publisher: "OASIS",
+        },
+        "OSLCSPR": {
+          title: "OSLC Core 2.0 Service Provider Resources",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification#Service_Provider_Resources",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCSPV": {
+          title: "OSLC Core 2.0 Selective Property Values",
+          href: "http://open-services.net/bin/view/Main/OslcCoreSpecification#Selective_Property_Values",
+          authors: ["S. Speicher", "D. Johnson"],
+          status: "Finalized",
+          publisher: "http://open-services.net",
+        },
+        "OSLCCore3": {
+          title: "OSLC Core 3.0",
+          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
+          authors: ["Steve Speicher"],
+          publisher: "OASIS",
+        },
+        "OSLCCoreVocab": {
+          title: "OSLC Core Vocabulary",
+          href: "http://open-services.net/specifications/core/core-vocab.html",
+          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "ResourcePreview": {
+          title: "OSLC Resource Preview 3.0",
+          href: "http://open-services.net/specifications/core/resource-preview.html",
+          authors: ["Jim Amsden", "S. Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "Dialogs": {
+          title: "OSLC Delegated Dialogs 3.0",
+          href: "http://open-services.net/specifications/core/dialogs.html",
+          authors: ["Samuel Padgett", "Steve Speicher"],
+          status: "Project Specification",
+          publisher: "OASIS",
+        },
+        "RDFVAL": {
+          title: "W3C RDF Validation Workshop",
+          href: "http://www.w3.org/2012/12/rdf-val/",
+          publisher: "W3C",
+        },
+        "RWLD": {
+          title: "Read-Write Linked Data",
+          href: "http://www.w3.org/DesignIssues/ReadWriteLinkedData.html",
+          authors: ["Tim Berners-Lee"],
+          publisher: "W3C",
+        },
+        "LDDI": {
+          title: "Linked Data Design Issues",
+          href: "http://www.w3.org/DesignIssues/LinkedData.html",
+          authors: ["Tim Berners-Lee"],
+          publisher: "W3C",
+        },
+        "TURTLE": {
+          title: "Turtle - Terse RDF Triple Language",
+          href: "http://www.w3.org/TR/turtle/",
+          authors: ["Tim Berners-Lee", "David Beckett", "Eric Prud'hommeaux", "Gavin Carothers"],
+          publisher: "W3C",
+        },
+        "REST": {
+          title: "Representational State Transfer (REST)",
+          href: "http://www.ics.uci.edu/%7Efielding/pubs/dissertation/rest_arch_style.htm",
+          authors: ["Roy Thomas Fielding"],
+          publisher: "University of California",
+        },
+        "LDOW2013": {
+          title: "OSLC Resource Shape: A language for defining constraints on Linked Data",
+          href: "http://events.linkeddata.org/ldow2013/papers/ldow2013-paper-02.pdf",
+          authors: ["Arthur Ryman", "Arnaud Le Hors", "Steve Speicher"],
+        },
+        "LDINT": {
+          title: "Linked Data Interfaces: Define REST API contracts for RDF resource representations",
+          href: "http://www.ibm.com/developerworks/rational/library/linked-data-oslc-resource-shapes/",
+          authors: ["Arthur Ryman"],
+          publisher: "IBM",
+        },
+        "ShapesRDFVAL": {
+          title: "OSLC Resource Shape: A Linked Data Constraint Language",
+          href: "http://www.w3.org/2001/sw/wiki/images/b/b7/RDFVal_Fokuoe_Ryman.pdf",
+          authors: ["Achille Fokoue", "Arthur Ryman"],
+          publisher: "W3C",
+        },
+        "OpenIDConnect": {
+          title: "OpenID Connect",
+          href: "http://openid.net/connect/",
+          publisher: "openid.net",
         }
-    }
-  };
-</script>
+      }
+    };
+  </script>
 </head>
 <body>
 

--- a/specs/core/resource-shape.html
+++ b/specs/core/resource-shape.html
@@ -4,83 +4,39 @@
 <head>
   <title>OSLC Core Version 3.0. Part 6: Resource Shape</title>
   <meta charset='utf-8'>
-  <script src='https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js' async class='remove'
-    type="text/javascript"></script>
+  <script src='./config.js' class='remove'></script>
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+    class='remove'></script>
+  <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
+    var fileName = "resource-shape.html";
     var respecConfig = {
-      specStatus: "PSD",
-      revision: "03",
-      publishDate: "2018-05-31",
+      // ===== Revision-specific settings =====
 
-      license: "cc-by-4",
+      specStatus: specConfig.status,
+      revision: specConfig.revision,
+      publishDate:  specConfig.publishDate,
+      previousPublishDate: specConfig.previousPublishDate,
+      previousMaturity: specConfig.previousMaturity,
 
-      additionalLicenses: [{
-        licenseName: "Apache License 2.0",
-        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
-      }],
+      // ===== Links =====
 
-      // if there a publicly available Editor's Draft, this is the link
-      edDraftURI: "https://raw.githack.com/oslc-op/oslc-specs/master/specs/core/resource-shape.html",
-      thisVersion: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html",
       prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
-      latestVersion: "http://open-services.net/specifications/core/resource-shape.html",
+      thisVersion: thisBase + fileName,
+      latestVersion: oasisBase + fileName,
+      latestSpecVersion: "https://open-services.net/spec/core/latest",
+      edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-      // Only include h1 and h2 level
-      maxTocLevel: 2,
-
-      shortName: "resource-shape",
-      conformanceLabelPrefix: "RS",
-      // the document's citation label
-      citationLabel: "OSLC-Shapes-3.0",
-
-
-      // if your specification has a subtitle that goes below the main
-      // formal title, define it here
-      // subtitle   :  "Committee Specification Draft 01",
-
-
-      wg: "OASIS OSLC OP",
-      wgShortName: "oslc-op",
-      wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
-
-      chairs: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }, {
-        name: "Andrii Berezovskyi",
-        mailto: "andriib@kth.se",
-        company: "KTH",
-        companyURL: "https://www.kth.se/en"
-      }],
-      editors: [{
-        name: "Jim Amsden",
-        mailto: "jamsden@us.ibm.com",
-        company: "IBM",
-        companyURL: "http://www.ibm.com/"
-      }, {
-        name: "Arthur Ryman",
-        mailto: "arthur.ryman@gmail.com",
-        company: "Ryerson University",
-        companyURL: "http://www.ryerson.ca/"
-      }],
-
-      namespaces: [{
-        href: "http://open-services.net/ns/core#",
-        prefix: "oslc"
-      }],
 
       // Other parts of multi-part spec
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: "http://open-services.net/specifications/core/v3.0/psprd04/oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: "http://open-services.net/specifications/core/v3.0/psprd04/discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: "http://open-services.net/specifications/core/v3.0/psprd04/dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: "http://open-services.net/specifications/core/v3.0/psprd04/attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape (this document)", href: "http://open-services.net/specifications/core/v3.0/psprd04/resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: "http://open-services.net/specifications/core/v3.0/psprd04/core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape (this document)", href: thisBase + "resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
       ],
 
       relatedWork: [
@@ -207,7 +163,54 @@
           href: "http://openid.net/connect/",
           publisher: "openid.net",
         }
-      }
+      },
+
+      // ===== Spec settings =====
+
+      maxTocLevel: 2,
+      shortName: "resource-shape",
+      conformanceLabelPrefix: "RS",
+      citationLabel: "OSLC-Shapes-3.0",
+      namespaces: [{
+        href: "http://open-services.net/ns/core#",
+        prefix: "oslc"
+      }],
+      editors: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "https://www.ibm.com/"
+      }, {
+        name: "Arthur Ryman",
+        mailto: "arthur.ryman@gmail.com",
+        company: "Ryerson University",
+        companyURL: "http://www.ryerson.ca/"
+      }],
+      license: "cc-by-4",
+      additionalLicenses: [{
+        licenseName: "Apache License 2.0",
+        licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
+      }],
+
+
+      // =====  Overall OSLC OP settings =====
+
+      wg: "OASIS OSLC OP",
+      wgShortName: "oslc-op",
+      wgURI: "https://github.com/oslc-op/oslc-specs",
+      wgPublicList: "oslc-op",
+
+      chairs: [{
+        name: "Jim Amsden",
+        mailto: "jamsden@us.ibm.com",
+        company: "IBM",
+        companyURL: "https://www.ibm.com/"
+      }, {
+        name: "Andrii Berezovskyi",
+        mailto: "andriib@kth.se",
+        company: "KTH",
+        companyURL: "https://www.kth.se/"
+      }],
     };
   </script>
 </head>

--- a/specs/core/resource-shape.html
+++ b/specs/core/resource-shape.html
@@ -184,7 +184,7 @@
         name: "Arthur Ryman",
         mailto: "arthur.ryman@gmail.com",
         company: "Ryerson University",
-        companyURL: "http://www.ryerson.ca/"
+        companyURL: "https://www.ryerson.ca/"
       }],
       license: "cc-by-4",
       additionalLicenses: [{

--- a/specs/core/resource-shape.html
+++ b/specs/core/resource-shape.html
@@ -21,14 +21,12 @@
 
       // ===== Links =====
 
-      prevVersion: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+      prevVersion: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
       thisVersion: thisBase + fileName,
       latestVersion: oasisBase + fileName,
       latestSpecVersion: "https://open-services.net/spec/core/latest",
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
-
-      // Other parts of multi-part spec
       additionalArtifacts: [
         { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
         { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
@@ -197,8 +195,7 @@
 
       wg: "OASIS OSLC OP",
       wgShortName: "oslc-op",
-      wgURI: "https://github.com/oslc-op/oslc-specs",
-      wgPublicList: "oslc-op",
+      wgURI: "https://open-services.net/about/",
 
       chairs: [{
         name: "Jim Amsden",


### PR DESCRIPTION
I have added `config.js` to store all common variables. The script is removed when you produce a published spec, so it does not have to be zipped for OASIS.

I have identified some discrepancy between config settings across parts, see newly filed issues.

Closes #104 