### PR TITLE
Add a note about content precedence.

### DIFF
--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -706,6 +706,8 @@ GET http://example.com/blogs/entry/1?oslc.paging=true&amp;amp;pageno=2
     </p>
 
     <p>OSLC Core 3.0 does not address compatibility with versions of OSLC prior to [[!OSLCCore2]]. Servers wishing to support compatibility with versions prior to 2.0 should follow <a href="http://open-services.net/bin/view/Main/OslcCoreSpecification#Specification_Versioning">OSLC Core 2.0 Specification Versioning</a>.</p>
+
+    <p>It is worth noting that in OSLC 2.0 specifications, normative specification text had precedence over machiner-readable content, as opposed to this specification.</p>
   </section>
 
 

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -707,7 +707,7 @@ GET http://example.com/blogs/entry/1?oslc.paging=true&amp;amp;pageno=2
 
     <p>OSLC Core 3.0 does not address compatibility with versions of OSLC prior to [[!OSLCCore2]]. Servers wishing to support compatibility with versions prior to 2.0 should follow <a href="http://open-services.net/bin/view/Main/OslcCoreSpecification#Specification_Versioning">OSLC Core 2.0 Specification Versioning</a>.</p>
 
-    <p>It is worth noting that in OSLC 2.0 specifications, normative specification text had precedence over machiner-readable content, as opposed to this specification.</p>
+    <p>It is worth noting that in OSLC 2.0 specifications, normative specification text had precedence over machine-readable content, as opposed to this specification.</p>
   </section>
 
 


### PR DESCRIPTION
We have this statement in the spec:

> Note that any machine-readable content (Computer Language Definitions) declared Normative for this Work Product is provided in separate plain text files. In the event of a discrepancy between any such plain text file and display content in the Work Product's prose narrative document(s), the content in the separate plain text file prevails.

But previous specs had different behaviour. Initially the discussed idea with Jim was to put both statements together in a normative section. In the process, I decided it would be better to keep the existing section normative in the header and add a new statement under an informative section (this PR).

Closes #120.