### PR TITLE
resolves #231

### DIFF
--- a/specs/rm/requirements-management-vocab.ttl
+++ b/specs/rm/requirements-management-vocab.ttl
@@ -27,7 +27,7 @@
 oslc_rm:  a                            owl:Ontology ;
         rdfs:label                     "Requirements Management(RM)" ;
         dcterms:description            "All vocabulary URIs defined in the OSLC Requirements Management (RM) namespace."^^rdf:XMLLiteral ;
-        dcterms:source                 <https://github.com/oslc-op/oslc-specs/blob/master/specs/blob/master/rm/requirements-management-vocab.ttl> ;
+        dcterms:source                 <https://github.com/oslc-op/oslc-specs/raw/master/specs/rm/requirements-management-vocab.ttl> ;
         dcterms:title                  "The OSLC Requirements Management(RM) Vocabulary" ;
         vann:preferredNamespacePrefix  "oslc_rm" .
 

--- a/specs/rm/requirements-management-vocab.ttl
+++ b/specs/rm/requirements-management-vocab.ttl
@@ -35,15 +35,13 @@ oslc_rm:  a                            owl:Ontology ;
 oslc_rm:Requirement  a      rdfs:Class ;
         rdfs:comment        "Statement of need." ;
         rdfs:isDefinedBy    oslc_rm: ;
-        rdfs:label          "Requirement" ;
-        oslc:hasBasicShape  oslc_rm:requirementShape .
+        rdfs:label          "Requirement" .
 
 oslc_rm:RequirementCollection
         a                   rdfs:Class ;
         rdfs:comment        "Collection of requirements. A collection uses zero or more requirements." ;
         rdfs:isDefinedBy    oslc_rm: ;
-        rdfs:label          "RequirementCollection" ;
-        oslc:hasBasicShape  <http://open-services-net/shapes/rm#requirementCollectionShape> .
+        rdfs:label          "RequirementCollection" .
 
 
 oslc_rm:implementedBy   a       rdf:Property ;


### PR DESCRIPTION
resolves #231

I removed the property oslc:hasBasicShape from the oslc_rm:Requirement & oslc_rm:RequirementCollection definitions. I checked and this property is not there for the CM specs for example.


oslc_rm:Requirement  a      rdfs:Class ;
        rdfs:comment        "Statement of need." ;
        rdfs:isDefinedBy    oslc_rm: ;
        rdfs:label          "Requirement" ;
        **oslc:hasBasicShape  oslc_rm:requirementShape** .
