### PR TITLE
Check the case for vocabulary terms

### DIFF
--- a/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/Terms.java
+++ b/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/Terms.java
@@ -93,6 +93,10 @@ public final class Terms
     @SCTerm(type=TermType.Class,description="A resource holding the check results for one property of one shape.")
     public static final Resource PropertyResult   = resource("PropertyResult");
 
+    /** Error class for a term with the wrong case. */
+    @SCIssue(issueSeverity=Warning,description="A vocabulary class must start with upper case, and a property with lower case.")
+    public static final Resource BadCase          = resource("BadCase");
+
     /** Error class for an oslc:impactType with an unknown value. */
     @SCIssue(issueSeverity=Error,description="Impact type must be one of oslc:UpstreamImpact, oslc:DownstreamImpact, oslc:SymmetricImpact, or oslc:NoImpact.")
     public static final Resource BadImpactType    = resource("BadImpactType");

--- a/tools/ShapeChecker/src/main/resources/SCVocabulary.ttl
+++ b/tools/ShapeChecker/src/main/resources/SCVocabulary.ttl
@@ -148,6 +148,13 @@ scheck:warnCount
 
 # Issues
 
+scheck:BadCase
+    a scheck:Issue ;
+    rdfs:isDefinedBy scheck: ;
+    rdfs:label "BadCase" ;
+    rdfs:comment "A vocabulary class must start with upper case, and a property with lower case." ;
+    scheck:severity scheck:Warning .
+
 scheck:BadImpactType
     a scheck:Issue ;
     rdfs:isDefinedBy scheck: ;


### PR DESCRIPTION
The first character of class names should be upper case.
The first character of property predicates should be lower case.