### PR TITLE
Show full URI in list of vocab terms

### DIFF
--- a/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/CrossCheck.java
+++ b/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/CrossCheck.java
@@ -135,7 +135,7 @@ public class CrossCheck
             System.out.println("\nList of vocabulary terms:");
             termsInVocabs.keySet()
                 .stream()
-                .map(r->r.getLocalName())
+                .map(r->r.toString())
                 .sorted()
                 .forEachOrdered(s->System.out.printf("   %s%n",s));
         }


### PR DESCRIPTION
The local name (previously shown) is insufficient for more complex term
URIs.