### PR TITLE
Editorial dhanges for PSD04

### DIFF
--- a/specs/core/actions.html
+++ b/specs/core/actions.html
@@ -5,7 +5,7 @@
   <meta charset='utf-8'>
   <title>OSLC Actions</title>
   <script src=
-              'https://raw.githack.com/oasis-tcs/tab-respec/master/builds/respec-oasis-common.js'
+              'https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js'
           async="" class='remove'>
   </script>
   <script type="text/javascript">
@@ -69,20 +69,6 @@
     } ],
 
     localBiblio : {
-        "OSLCCore3" : {
-          title:    "OSLC Core 3.0",
-          href:     "http://open-services.net/specifications/core/oslc-core.html",
-          authors:  ["Jim Amsden", "S. Speicher"],
-          status:   "Project Specification",
-          publisher:  "OASIS",
-        },
-      "OSLCCoreVocab" : {
-          title : "OSLC Core Vocabulary",
-          href : "http://open-services.net/specifications/core/core-vocab.html",
-          authors : [ "Jim Amsden", "S. Padgett", "S. Speicher" ],
-          status:   "Project Specification",
-          publisher : "OASIS",
-      },
     }
   };
   </script>

--- a/specs/core/actions.html
+++ b/specs/core/actions.html
@@ -24,7 +24,7 @@
     // Only include h1 and h2 level
     maxTocLevel: 2,
 
-    shortName : "oslc-actions",
+    shortName : "actions",
     conformanceLabelPrefix: "Actions",
 
     // if there a publicly available Editor's Draft, this is the link

--- a/specs/core/attachments.html
+++ b/specs/core/attachments.html
@@ -28,13 +28,13 @@
       // ===== Links =====
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments (this document)", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments (this document)", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href:"core-vocab.html" }
       ],
 
       relatedWork: [
@@ -52,7 +52,7 @@
 
       // ===== Spec settings =====
 
-      shortName: "OSLC Attachments 3.0",
+      shortName: "attachments",
       conformanceLabelPrefix: "AT",
       citationLabel: "OSLC-Attachments-3.0",
       maxTocLevel: 2,

--- a/specs/core/attachments.html
+++ b/specs/core/attachments.html
@@ -5,7 +5,7 @@
   <meta charset='utf-8' />
   <title>OSLC Core Version 3.0. Part 5: Attachments</title>
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -42,20 +42,6 @@
       ],
 
       localBiblio: {
-        "OSLCCore3": {
-          title: "OSLC Core 3.0",
-          href: "http://open-services.net/specifications/core/oslc-core.html",
-          authors: ["Jim Amsden", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "OSLCCoreVocab": {
-          title: "OSLC Core Vocabulary",
-          href: "http://open-services.net/specifications/core/core-vocab.html",
-          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
         "PURLMediaTypes": {
           title: "Media Types",
           href: "http://www.iana.org/assignments/media-types/media-types.xhtml",
@@ -164,7 +150,7 @@ discovery, get, create, update or delete attachments and associate with a web re
 
 <section id="terms">
 <h1>Terminology</h1>
-<p>Terminology uses and extends the terminology and capabilities of OSLC Core Overview [[!OSLCCore3]], W3C Linked Data Platform [[!LDP]], W3C's
+<p>Terminology uses and extends the terminology and capabilities of <a href="./oslc-core.html">OSLC Core Overview</a>, W3C Linked Data Platform [[!LDP]], W3C's
     Architecture of the World Wide Web [[WEBARCH]],  Hyper-text
     Transfer Protocol [[!HTTP11]].</p>
 <dl>
@@ -711,7 +697,7 @@ Content-Length: 0
 <section id="descriptor_shape">
 <h2>Resource: AttachmentDescriptor</h2>
 
-<p>This document applies the following constraints to the [[!OSLCCoreVocab]] vocabulary terms.</p>
+<p>This document applies the following constraints to the <a href="./core-vocab.html">OSLCCoreVocab vocabulary</a> terms.</p>
 
 <p class='conformance'>An OSLC server providing the Attachments capability MUST implement the vocabulary defined in this section.</p>
 

--- a/specs/core/config.js
+++ b/specs/core/config.js
@@ -1,5 +1,5 @@
 var specConfig = {
-  status: "PSD",
+  status: "WD",
   revision: "04",
   publishDate: '2019-12-20',
   previousPublishDate: "2018-05-31",

--- a/specs/core/config.js
+++ b/specs/core/config.js
@@ -1,7 +1,7 @@
 var specConfig = {
-  status: "WD",
+  status: "PSD",
   revision: "04",
-  publishDate: null,
+  publishDate: '2019-12-20',
   previousPublishDate: "2018-05-31",
   previousMaturity: "CSPRD",
 };

--- a/specs/core/core-vocab.html
+++ b/specs/core/core-vocab.html
@@ -28,13 +28,13 @@
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary (this document)", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary (this document)", href:"core-vocab.html" }
       ],
 
       relatedWork: [
@@ -72,7 +72,7 @@
       // ===== Spec settings =====
 
       maxTocLevel: 2,
-      shortName: "oslc-core",
+      shortName: "core-vocab",
       subtitle: "Core Vocabulary",
       citationLabel: "OSLC-CoreVocab-3.0",
       noConformanceTable: true,

--- a/specs/core/core-vocab.html
+++ b/specs/core/core-vocab.html
@@ -5,7 +5,7 @@
   <title>OSLC Core Version 3.0. Part 7: Vocabulary</title>
   <meta charset='utf-8' />
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -48,18 +48,6 @@
           authors: ["S. Speicher", "D. Johnson"],
           status: "Finalized",
           publisher: "http://open-services.net",
-        },
-        "OSLCCore3": {
-          title: "OSLC Core 3.0",
-          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
-          authors: ["Steve Speicher"],
-          publisher: "OASIS",
-        },
-        "ResourceShapes": {
-          title: "OSLC Resource Shape 3.0",
-          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part6-resource-shape.html",
-          authors: ["Arthur Ryman", "Jim Amsden"],
-          publisher: "OASIS",
         },
         "SysML": {
           title: "System Modeling Language",
@@ -139,7 +127,7 @@
 
     <section id="terms">
         <h1>Terminology</h1>
-        <p>Terminology uses and extends the terminology and capabilities of OSLC Core Overview [[!OSLCCore3]], W3C Linked Data Platform [[!LDP]], W3C's
+        <p>Terminology uses and extends the terminology and capabilities of <a href=./oslc-core.html>OSLC Core Overview</a>, W3C Linked Data Platform [[!LDP]], W3C's
             Architecture of the World Wide Web [[WEBARCH]],  Hyper-text
             Transfer Protocol [[!HTTP11]].</p>
         <dl>
@@ -182,7 +170,7 @@
             <li>Specify what servers all allow for prefilling delegated dialogs.</li>
             <li>Describe the results of query operations.</li>
         </ul></p>
-        <p>Constraints on OSLC Core and Domain resources SHOULD be described using [[!ResourceShapes]] which is included as part of the OSLC Core multi-part specifications. Servers MAY use other constraint languages such as [[SHACL]] to define resource constraints.</p>
+        <p>Constraints on OSLC Core and Domain resources SHOULD be described using <a href="./resource-shape.html">ResourceShapes</a> which is included as part of the OSLC Core multi-part specifications. Servers MAY use other constraint languages such as [[SHACL]] to define resource constraints.</p>
     </section>
 
     <section id="enumerations" class="informative">

--- a/specs/core/dialogs.html
+++ b/specs/core/dialogs.html
@@ -5,7 +5,7 @@
   <meta charset='utf-8' />
   <title>OSLC Core Version 3.0. Part 4: Delegated Dialogs</title>
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -42,27 +42,6 @@
       ],
 
       localBiblio: {
-        "OSLCCore3": {
-          title: "OSLC Core 3.0",
-          href: "http://open-services.net/specifications/core/oslc-core.html",
-          authors: ["Jim Amsden", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "OSLCCoreVocab": {
-          title: "OSLC Core Vocabulary",
-          href: "http://open-services.net/specifications/core/core-vocab.html",
-          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "OSLCPreview30": {
-          title: "OSLC Resource Preview 3.0",
-          href: "http://open-services.net/specifications/core/resource-preview.html",
-          authors: ["Jim Amsden", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
         "OSLCCore2": {
           title: "OSLC Core 2.0",
           href: "http://open-services.net/bin/view/Main/OslcCoreSpecification",
@@ -172,7 +151,7 @@
 <section class="glossary" id="terminology">
 <h2>Terminology</h2>
 
-<p>Terminology uses and extends the terminology and capabilities of OSLC Core Overview [[!OSLCCore3]], W3C Linked Data
+<p>Terminology uses and extends the terminology and capabilities of <a href=./oslc-core.html>OSLC Core Overview</a>, W3C Linked Data
 Platform [[!LDP]], W3C's Architecture of the World Wide Web [[WEBARCH]],
 and Hyper-text Transfer Protocol [[!HTTP11]].</p>
 
@@ -453,7 +432,7 @@ Host: example.com
 
   <p>When embedded in an <code>iframe</code>, dialogs may also request to be
       resized dynamically. These requests are the same as specified in
-      [[OSLCPreview30]] and also use <code>postMessage</code>.  Clients can
+      <a href="./resource-preview.html">OSLC Resource Preview</a> and also use <code>postMessage</code>.  Clients can
       distinguish between results and resize messages from the message prefix.
       Messages have the following prefixes:</p>
 
@@ -610,8 +589,7 @@ Transfer-Encoding: chunked
 </pre>
 
 <p>The content of the request depends on the type of dialog and the server.
-    Servers may describe constraints on POST content using resource shapes
-    [[!OSLCCoreVocab]]. The dialog descriptor uses property
+    Servers may describe constraints on POST content using <a href="./resource-shape.html">ResourceShapes</a>. The dialog descriptor uses property
     <code>oslc:resourceShape</code> for the shape constraints.</p>
 
 <p>The server's response contains a <code>Location</code> header with the
@@ -834,7 +812,7 @@ function handleMessage(event) {
 
         <p id="resize" class='conformance'>
             Dialogs MAY support dynamic resizing as specified in
-            [[!OSLCPreview30]].
+            <a href="./resource-preview.html">OSLC Resource Preview</a>.
         </p>
         <p id="ignore_unrecognized_messages" class='conformance'>
             Clients MUST anticipate other, unrelated uses of
@@ -894,7 +872,7 @@ Allow: GET,POST,HEAD,OPTIONS
 
 <section id="dialog_shape">
     <h2>Resource Constraints</h2>
-    <p>This document applies the following constraints to the Dialog [[!OSLCCoreVocab]] vocabulary term.</p>
+    <p>This document applies the following constraints to the <a href="./core-vocab.html">Core vocabulary</a> terms.</p>
     <p class='conformance'>An OSLC server providing Dialog capability MUST implement the vocabulary defined in this section.</p>
 
     <div title='Resource Constraints for Dialog'

--- a/specs/core/dialogs.html
+++ b/specs/core/dialogs.html
@@ -28,13 +28,13 @@
       // ===== Links =====
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs (this document)", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs (this document)", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href:"core-vocab.html" }
       ],
 
       relatedWork: [
@@ -53,7 +53,7 @@
 
       // ===== Spec settings =====
 
-      shortName: "OSLC Delegated Dialogs 3.0",
+      shortName: "dialogs",
       conformanceLabelPrefix: "DD",
       citationLabel: "OSLC-Dialogs-3.0",
       maxTocLevel: 2,

--- a/specs/core/discovery.html
+++ b/specs/core/discovery.html
@@ -28,13 +28,13 @@
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery (this document)", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery (this document)", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href:"core-vocab.html" }
       ],
 
       relatedWork: [
@@ -79,7 +79,7 @@
 
       // ===== Spec settings =====
 
-      shortName: "oslc-discovery",
+      shortName: "discovery",
       conformanceLabelPrefix: "DIS",
       citationLabel: "OSLC-Discovery-3.0",
       maxTocLevel: 2,

--- a/specs/core/discovery.html
+++ b/specs/core/discovery.html
@@ -5,7 +5,7 @@
   <title>OSLC Core Version 3.0. Part 2: Discovery</title>
   <meta charset='utf-8'>
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -69,34 +69,6 @@
           authors: ["S. Speicher", "D. Johnson"],
           status: "Finalized",
           publisher: "http://open-services.net",
-        },
-        "OSLCCore3": {
-          title: "OSLC Core 3.0",
-          href: "http://open-services.net/specifications/core/oslc-core.html",
-          authors: ["Jim Amsden", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "OSLCCoreVocab": {
-          title: "OSLC Core Vocabulary",
-          href: "http://open-services.net/specifications/core/core-vocab.html",
-          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "ResourcePreview": {
-          title: "OSLC Resource Preview 3.0",
-          href: "http://open-services.net/specifications/core/resource-preview.html",
-          authors: ["Samuel Padgett", "Steve Speicher", "Jim Amsden"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "Dialogs": {
-          title: "OSLC Delegated Dialogs 3.0",
-          href: "http://open-services.net/specifications/core/dialogs.html",
-          authors: ["Samuel Padgett", "Steve Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
         },
         "OpenIDConnect": {
           title: "OpenID Connect",
@@ -172,7 +144,7 @@
 
     <section id="terms">
         <h1>Terminology</h1>
-        <p>Terminology uses and extends the terminology and capabilities of OSLC Core Overview [[!OSLCCore3]], W3C Linked Data Platform [[!LDP]], W3C's
+        <p>Terminology uses and extends the terminology and capabilities of <a href=./oslc-core.html>OSLC Core Overview</a>, W3C Linked Data Platform [[!LDP]], W3C's
             Architecture of the World Wide Web [[WEBARCH]],  Hyper-text
             Transfer Protocol [[!HTTP11]].</p>
         <dl>
@@ -348,7 +320,7 @@
             </p>
 
       <p id="createsWithShapes" class='conformance'>
-        In a response to an HTTP <code>OPTIONS</code>, <code>HEAD</code> or <code>GET</code> method on a given Request-URI referencing an LDPC, servers SHOULD include a <code>Link</code> header with the relation-type set to <code>rel="http://open-services.net/core#constrainedBy"</code> and the Target URI set to the URI of a resource that defines constraints on the to-be created or updated resource representation in the LDPC. The resource referenced by Target URI is RECOMMENDED to be a machine-readable representation such as OSLC Resource Shape [[!OSLCCoreVocab]], but MAY be some variant or other constraint document. See [[!LDP]] <a href="http://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs">section about server published constraints</a>.
+        In a response to an HTTP <code>OPTIONS</code>, <code>HEAD</code> or <code>GET</code> method on a given Request-URI referencing an LDPC, servers SHOULD include a <code>Link</code> header with the relation-type set to <code>rel="http://open-services.net/core#constrainedBy"</code> and the Target URI set to the URI of a resource that defines constraints on the to-be created or updated resource representation in the LDPC. The resource referenced by Target URI is RECOMMENDED to be a machine-readable representation such as <a href="./resource-shape.html">OSLC ResourceShapes</a>, but MAY be some variant or other constraint document. See [[!LDP]] <a href="http://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs">section about server published constraints</a>.
       </p>
 
         <pre class='example'>
@@ -357,7 +329,7 @@
         <p>The link header in the example above would be returned on an OPTIONS or HEAD request to a resource of type <code>&lt;http://open-services.net/ns/cm#Bug&gt;</code> to provide the URI of the creation or update constraints.</p>
 
             <p id="createError" class='conformance'>
-                In a response to an HTTP <code>POST</code> or <code>PUT</code> method on a given Request-URI referencing an LDPC, servers SHOULD include a <code>Link</code> header with the relation-type set to <code>rel="http://open-services.net/core#constrainedBy"</code> and the Target URI set to the URI of a resource that defines constraints that on the to-be created or updated resource representation in the LDPC that were not satisfied. The resource referenced by Target URI is RECOMMENDED to be a machine-readable representation such as OSLC Resource Shape [[!OSLCCoreVocab]], but MAY be some variant or other constraint document. See [[!LDP]] <a href="http://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs">section about server published constraints</a>.
+                In a response to an HTTP <code>POST</code> or <code>PUT</code> method on a given Request-URI referencing an LDPC, servers SHOULD include a <code>Link</code> header with the relation-type set to <code>rel="http://open-services.net/core#constrainedBy"</code> and the Target URI set to the URI of a resource that defines constraints that on the to-be created or updated resource representation in the LDPC that were not satisfied. The resource referenced by Target URI is RECOMMENDED to be a machine-readable representation such as  <a href="./resource-shape.html">OSLC ResourceShapes</a>, but MAY be some variant or other constraint document. See [[!LDP]] <a href="http://www.w3.org/TR/ldp/#ldpr-gen-pubclireqs">section about server published constraints</a>.
             </p>
 
                 <pre class='example'>
@@ -374,12 +346,11 @@
         </section>
 
         <section id="uiPreview"><h2>Resource User Interface Preview Discovery</h2>
-            <p>See [[!ResourcePreview]] for resource preview discovery using the
-            the <code>Link</code> header or the <code>Prefer</code> header.</p>
+            <p>See <a href="./resource-preview.html">OSLC Resource Preview</a> for resource preview discovery using the <code>Link</code> header or the <code>Prefer</code> header.</p>
         </section>
 
         <section id="dialogs"><h2>Resource User Interface Delegated Dialogs Discovery</h2>
-            <p>See [[!Dialogs]] for resource selection and creation delegated UI discovery using the <a href="http://open-services.net/bin/view/Main/OslcCoreSpecification#Delegated_User_Interface_Dialogs"><code>http://open-services.net/ns/core#selectionDialog</code></a> or <a href="http://open-services.net/bin/view/Main/OslcCoreSpecification#Delegated_User_Interface_Dialogs"><code>http://open-services.net/ns/core#creationDialog</code></a> properties of a Service resource, or the <code>Link</code> header or the <code>Prefer</code> header.
+            <p>See <a href="./dialogs.html">Delegated dialogs</a> for resource selection and creation delegated UI discovery using the <a href="http://open-services.net/bin/view/Main/OslcCoreSpecification#Delegated_User_Interface_Dialogs"><code>http://open-services.net/ns/core#selectionDialog</code></a> or <a href="http://open-services.net/bin/view/Main/OslcCoreSpecification#Delegated_User_Interface_Dialogs"><code>http://open-services.net/ns/core#creationDialog</code></a> properties of a Service resource, or the <code>Link</code> header or the <code>Prefer</code> header.
             </p>
         </section>
 
@@ -402,7 +373,7 @@
 <section id="resourceConstraints">
 <h2>Resource Constraints</h2>
 
-<p>This document applies the following constraints to the [[!OSLCCoreVocab]] vocabulary terms.</p>
+<p>This document applies the following constraints to the <a href="./core-vocab.html">OSLC Core vocabulary</a> terms.</p>
 
 <section id="serviceProviderCatalogShape">
 <h2 id="resourceServiceProviderCatalog">Resource: ServiceProviderCatalog</h2>

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -27,13 +27,13 @@
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview (this document)", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview (this document)", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href:"core-vocab.html" }
       ],
 
       relatedWork: [

--- a/specs/core/oslc-core.html
+++ b/specs/core/oslc-core.html
@@ -4,7 +4,7 @@
   <meta charset='utf-8' />
   <title>OSLC Core Version 3.0. Part 1: Overview</title>
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -628,9 +628,12 @@ GET http://example.com/blogs/entry/1?oslc.paging=true&amp;amp;pageno=2
     <section id="usingResourcePaging">
     <h3>Using Resource Paging</h3>
       <p class='conformance'>
-        OSLC Services SHOULD support [[!LDPPaging]] to enable clients to retrieve large LDP resources (LDPRs) a page at a time.
+        OSLC Services MAY support [[!LDPPaging]] to enable clients to retrieve large LDP resources (LDPRs) a page at a time.
       </p>
 
+      <p class='conformance'>
+        OSLC Services SHOULD support OSLC paging as described in this section to ensure compatibility with OSLC 2.0 server implementations.
+      </p>
     <p class='conformance'>To request a paged version of a resource, a client MUST add at least one "key=value" pair to the query component of the resource URI: Either oslc.paging=true, or oslc.pageSize, or both.</p>
     <p class='conformance'> When responding to a request that includes oslc.paging=true in the URI, a server MAY return a representation that contains a subset of the resource's property values.</p>
     <p>By adding oslc.pageSize to the query component of the resource URI, the client requests that the server respond with a specific number of property values. For example, oslc.pageSize=20 indicates to the server that the client would like 20 values per page.</p>

--- a/specs/core/resource-preview.html
+++ b/specs/core/resource-preview.html
@@ -28,13 +28,13 @@
       // ===== Links =====
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview (this document)", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview (this document)", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href:"core-vocab.html" }
       ],
 
       relatedWork: [

--- a/specs/core/resource-preview.html
+++ b/specs/core/resource-preview.html
@@ -5,7 +5,7 @@
   <meta charset='utf-8' />
   <title>OSLC Core Version 3.0. Part 3: Resource Preview</title>
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -43,25 +43,12 @@
 
 
       localBiblio: {
-        "OSLCCore3": {
-          title: "OSLC Core 3.0",
-          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
-          authors: ["Steve Speicher"],
-          publisher: "OASIS",
-        },
         "OSLCUIPreview20": {
           title: "OSLC Core 2.0 - UI Preview",
           href: "http://open-services.net/bin/view/Main/OslcCoreUiPreview",
           authors: ["S. Bosworth"],
           status: "Finalized",
           publisher: "http://open-services.net"
-        },
-        "OSLCCoreVocab": {
-          title: "OSLC Core Vocabulary",
-          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part7-core-vocabulary.html",
-          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
-          status: "Working Draft",
-          publisher: "OASIS",
         },
         "JSONSchema": {
           title: "JSON Schema",
@@ -153,7 +140,7 @@
 <section id="terminology">
 <h2>Terminology</h2>
 
-<p>Terminology uses and extends the terminology and capabilities of OSLC Core Overview [[!OSLCCore3]], W3C Linked Data Platform [[!LDP]], W3C's Architecture of the World Wide Web [[WEBARCH]], and Hyper-text Transfer Protocol [[!HTTP11]].</p>
+<p>Terminology uses and extends the terminology and capabilities of <a href=./oslc-core.html>OSLC Core Overview</a>, W3C Linked Data Platform [[!LDP]], W3C's Architecture of the World Wide Web [[WEBARCH]], and Hyper-text Transfer Protocol [[!HTTP11]].</p>
 
 <p>The following terms are used in discussions of previews:</p>
 
@@ -884,7 +871,7 @@ oslc-preview-height:277
 <section id="resources">
 <h2>Resource Constraints</h2>
 
-<p>This document applies the following constraints to the [[!OSLCCoreVocab]] vocabulary terms.</p>
+<p>This document applies the following constraints to the <a href="./core-vocab.html">OSLC Core vocabulary</a> terms.</p>
 
 <p class='conformance'>An OSLC server providing the Resource Preview capability MUST implement the vocabulary defined in this section.</p>
 

--- a/specs/core/resource-shape.html
+++ b/specs/core/resource-shape.html
@@ -28,13 +28,13 @@
       edDraftURI: "https://open-services.net/spec/core/latest-draft",
 
       additionalArtifacts: [
-        { title: "OSLC Core Version 3.0. Part 1: Overview", href: thisBase + "oslc-core.html" },
-        { title: "OSLC Core Version 3.0. Part 2: Discovery", href: thisBase + "discovery.html" },
-        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href: thisBase + "resource-preview.html" },
-        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href: thisBase + "dialogs.html" },
-        { title: "OSLC Core Version 3.0. Part 5: Attachments", href: thisBase + "attachments.html" },
-        { title: "OSLC Core Version 3.0. Part 6: Resource Shape (this document)", href: thisBase + "resource-shape.html" },
-        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href: thisBase + "core-vocab.html" }
+        { title: "OSLC Core Version 3.0. Part 1: Overview", href:"oslc-core.html" },
+        { title: "OSLC Core Version 3.0. Part 2: Discovery", href:"discovery.html" },
+        { title: "OSLC Core Version 3.0. Part 3: Resource Preview", href:"resource-preview.html" },
+        { title: "OSLC Core Version 3.0. Part 4: Delegated Dialogs", href:"dialogs.html" },
+        { title: "OSLC Core Version 3.0. Part 5: Attachments", href:"attachments.html" },
+        { title: "OSLC Core Version 3.0. Part 6: Resource Shape (this document)", href:"resource-shape.html" },
+        { title: "OSLC Core Version 3.0. Part 7: Vocabulary", href:"core-vocab.html" }
       ],
 
       relatedWork: [

--- a/specs/core/resource-shape.html
+++ b/specs/core/resource-shape.html
@@ -5,7 +5,7 @@
   <title>OSLC Core Version 3.0. Part 6: Resource Shape</title>
   <meta charset='utf-8'>
   <script src='./config.js' class='remove'></script>
-  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.6/builds/respec-oasis-common.min.js' async
+  <script src='https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.13/builds/respec-oasis-common.min.js' async
     class='remove'></script>
   <!-- <script src='http://127.0.0.1:9000/respec-oasis-common.js' async class='remove'></script> -->
   <script class='remove'>
@@ -82,33 +82,6 @@
           authors: ["S. Speicher", "D. Johnson"],
           status: "Finalized",
           publisher: "http://open-services.net",
-        },
-        "OSLCCore3": {
-          title: "OSLC Core 3.0",
-          href: "http://docs.oasis-open.org/oslc-core/oslc-core/v3.0/oslc-core-v3.0-part1-overview.html",
-          authors: ["Steve Speicher"],
-          publisher: "OASIS",
-        },
-        "OSLCCoreVocab": {
-          title: "OSLC Core Vocabulary",
-          href: "http://open-services.net/specifications/core/core-vocab.html",
-          authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "ResourcePreview": {
-          title: "OSLC Resource Preview 3.0",
-          href: "http://open-services.net/specifications/core/resource-preview.html",
-          authors: ["Jim Amsden", "S. Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
-        },
-        "Dialogs": {
-          title: "OSLC Delegated Dialogs 3.0",
-          href: "http://open-services.net/specifications/core/dialogs.html",
-          authors: ["Samuel Padgett", "Steve Speicher"],
-          status: "Project Specification",
-          publisher: "OASIS",
         },
         "RDFVAL": {
           title: "W3C RDF Validation Workshop",
@@ -284,7 +257,7 @@
             (e.g. GET, POST) and the integrity constraints that must be satisfied
             by the contents in that context.</p>
 
-        <p>Resource shapes specify a standard way of describing resources and constraints on resources that may be used in defining among other things, OSLC domain resources. There are other means that OSLC domains may use in addition to or instead of resource shapes such as W3C [[SHACL]] or [[JSONSchema]]. OSLC servers should describe their resources using resource shapes if they wish to integrate with [[!OSLCCore3]] clients or servers that are expecting resource shapes. OSLC domain specifications use shapes to specify the constraints on their domain vocabulary elements that must be supported by servers.</p>
+        <p>Resource shapes specify a standard way of describing resources and constraints on resources that may be used in defining among other things, OSLC domain resources. There are other means that OSLC domains may use in addition to or instead of resource shapes such as W3C [[SHACL]] or [[JSONSchema]]. OSLC servers should describe their resources using resource shapes if they wish to integrate with <a href=./oslc-core.html>OSLC Core 3.0</a> clients or servers that are expecting resource shapes. OSLC domain specifications use shapes to specify the constraints on their domain vocabulary elements that must be supported by servers.</p>
 
         <p>This specification begins with a brief discussion of the use cases
             and requirements that the OSLC Resource Shape Specification addresses. It
@@ -294,7 +267,7 @@
 
     <section id="terms">
         <h1>Terminology</h1>
-        <p>Terminology uses and extends the terminology and capabilities of OSLC Core Overview [[!OSLCCore3]], W3C Linked Data Platform [[!LDP]], W3C's Architecture of the World Wide Web [[WEBARCH]],  Hyper-text
+        <p>Terminology uses and extends the terminology and capabilities of <a href=./oslc-core.html>OSLC Core Overview</a>, W3C Linked Data Platform [[!LDP]], W3C's Architecture of the World Wide Web [[WEBARCH]],  Hyper-text
             Transfer Protocol [[!HTTP11]].</p>
             <p>This specification introduces the following terminology:</p>
             <dl>
@@ -484,7 +457,7 @@
     <h2>Shape Resources</h2>
         <p>
             This section describes the Resource Shape specification (aka
-            the <em>Shapes</em> specification) which is part of [[!OSLCCore3]]. The
+            the <em>Shapes</em> specification) which is part of <a href=./oslc-core.html>OSLC Core 3.0</a>. The
             Shapes specification defines:
         </p>
         <ul>


### PR DESCRIPTION
No significant changes other than switching priority of LDP vs OSLC paging. The rest are editorial changes required for publishing the first oslc-op Core PSD.