### PR TITLE
Updates for PSD05

### DIFF
--- a/specs/core/shapes/AttachmentDescriptor-shape.ttl
+++ b/specs/core/shapes/AttachmentDescriptor-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix oslc: <http://open-services.net/ns/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

--- a/specs/core/shapes/Comment-shape.ttl
+++ b/specs/core/shapes/Comment-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/specs/core/shapes/CommonProperties-shape.ttl
+++ b/specs/core/shapes/CommonProperties-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix foaf: <http://xmlns.com/foaf/0.1/> .
 @prefix oslc: <http://open-services.net/ns/core#> .
@@ -26,6 +40,7 @@
             <#serviceProvider>,
             <#instanceShape>,
             <#queryable>,
+            <#archived>,
             <#shortTitle>,
             <#shortId>,
             <#discussedBy>,
@@ -36,6 +51,7 @@
 <#contributor>  a                 oslc:Property ;
         oslc:name                "contributor" ;
         oslc:range               foaf:Person ;
+        oslc:range               oslc:Any ;
         oslc:occurs              oslc:Zero-or-many ;
         oslc:propertyDefinition  dcterms:contributor ;
         oslc:valueType           oslc:AnyResource ;
@@ -45,6 +61,7 @@
 <#creator>  a                 oslc:Property ;
         oslc:name                "creator" ;
         oslc:range               foaf:Person ;
+        oslc:range               oslc:Any ;
         oslc:occurs              oslc:Zero-or-many ;
         oslc:propertyDefinition  dcterms:creator ;
         oslc:valueType           oslc:AnyResource ;
@@ -165,6 +182,13 @@ and olsc.select clause) or not. Defaults to true if unspecified."""^^rdf:XMLLite
     oslc:propertyDefinition  oslc:queryable ;
     oslc:valueType xsd:boolean .
 
+<#archived> a oslc:Property ;
+    oslc:name "archived" ;
+    oslc:occurs oslc:Zero-or-one;
+    dcterms:description """Indicates whether the subject has been marked as archived, no longer an actively updating resource."""^^rdf:XMLLiteral ;
+    oslc:propertyDefinition  oslc:archived ;
+    oslc:valueType xsd:boolean .
+
 <#shortTitle> a oslc:Property ;
     oslc:name "shortTitle" ;
     oslc:occurs oslc:Zero-or-many;
@@ -191,6 +215,7 @@ and olsc.select clause) or not. Defaults to true if unspecified."""^^rdf:XMLLite
 <#modifiedBy> a oslc:Property ;
     oslc:name "modifiedBy" ;
     oslc:range foaf:Person ;
+    oslc:range oslc:Any ;
     oslc:propertyDefinition oslc:modifiedBy  ;
     oslc:occurs oslc:Zero-or-many;
     dcterms:description """The URI of a resource describing the entity that most recently modified the

--- a/specs/core/shapes/Compact-shape.ttl
+++ b/specs/core/shapes/Compact-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .

--- a/specs/core/shapes/CreationFactory-shape.ttl
+++ b/specs/core/shapes/CreationFactory-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/Dialog-shape.ttl
+++ b/specs/core/shapes/Dialog-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix oslc: <http://open-services.net/ns/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

--- a/specs/core/shapes/Discussion-shape.ttl
+++ b/specs/core/shapes/Discussion-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/specs/core/shapes/Error-shape.ttl
+++ b/specs/core/shapes/Error-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/specs/core/shapes/ExtendedError-shape.ttl
+++ b/specs/core/shapes/ExtendedError-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .

--- a/specs/core/shapes/OAuthConfiguration-shape.ttl
+++ b/specs/core/shapes/OAuthConfiguration-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/PrefixDefinition-shape.ttl
+++ b/specs/core/shapes/PrefixDefinition-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/Preview-shape.ttl
+++ b/specs/core/shapes/Preview-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .

--- a/specs/core/shapes/Publisher-shape.ttl
+++ b/specs/core/shapes/Publisher-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/QueryCapability-shape.ttl
+++ b/specs/core/shapes/QueryCapability-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/ResourceShapes-shape.ttl
+++ b/specs/core/shapes/ResourceShapes-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix foaf:           <http://xmlns.com/foaf/0.1/> .
 @prefix ldp:            <http://www.w3.org/ns/ldp#> .

--- a/specs/core/shapes/ResponseInfo-shape.ttl
+++ b/specs/core/shapes/ResponseInfo-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .

--- a/specs/core/shapes/Service-shape.ttl
+++ b/specs/core/shapes/Service-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/ServiceProvider-shape.ttl
+++ b/specs/core/shapes/ServiceProvider-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/shapes/ServiceProviderCatalog-shape.ttl
+++ b/specs/core/shapes/ServiceProviderCatalog-shape.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>.

--- a/specs/core/vocab/core-vocab.ttl
+++ b/specs/core/vocab/core-vocab.ttl
@@ -1,3 +1,17 @@
+# Copyright 2019 OASIS Open
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 @prefix dcterms: <http://purl.org/dc/terms/>.
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -479,6 +493,19 @@ In the context of other resources, the value SHOULD be the total number of prope
 values (i.e. RDF triples) of the resource. Unless Stable Paging is in effect, the
 total count MAY vary as a client retrieves subsequent pages.""" .
 
+oslc:score
+  a rdf:Property ;
+  rdfs:label "score" ;
+  rdfs:comment """A computed property for each member resource of a full text search query indicating the quality of the
+  match, and sort them in descending order of score.""" .
+
+oslc:order
+  a rdf:Property ;
+  rdfs:label "score" ;
+  rdfs:comment """A computed property for each member resource of a query with an orderBy clause 
+  supporting sorting of the RDF results.""" .
+
+
 oslc:nextPage
   a rdf:Property ;
   rdfs:isDefinedBy oslc: ;
@@ -745,3 +772,14 @@ oslc:executes
   rdfs:isDefinedBy oslc: ;
   rdfs:label "executes" ;
   rdfs:comment "Link from a currently available action to the future action it realizes." .
+
+oslc:publisher
+  a rdf:property ;
+  rdfs: rdfs:isDefinedBy oslc: ;
+  rdfs:label "publisher" ;
+  rdfs:comment "An entity responsible for making the resource available. Servers should use dcterms:publisher" ;
+  vs:term_status "archaic" .
+
+
+
+

--- a/specs/core/vocab/core-vocab.ttl
+++ b/specs/core/vocab/core-vocab.ttl
@@ -774,8 +774,8 @@ oslc:executes
   rdfs:comment "Link from a currently available action to the future action it realizes." .
 
 oslc:publisher
-  a rdf:property ;
-  rdfs: rdfs:isDefinedBy oslc: ;
+  a rdf:Property ;
+  rdfs:isDefinedBy oslc: ;
   rdfs:label "publisher" ;
   rdfs:comment "An entity responsible for making the resource available. Servers should use dcterms:publisher" ;
   vs:term_status "archaic" .

--- a/specs/core/vocab/core-vocab.ttl
+++ b/specs/core/vocab/core-vocab.ttl
@@ -501,7 +501,7 @@ oslc:score
 
 oslc:order
   a rdf:Property ;
-  rdfs:label "score" ;
+  rdfs:label "order" ;
   rdfs:comment """A computed property for each member resource of a query with an orderBy clause 
   supporting sorting of the RDF results.""" .
 


### PR DESCRIPTION
I think we need another PSD revision before creating PS01.
* Adds the license text to all the .ttl files
* added oslc:score and oslc:order properties to core vocab
* added oslc:publisher deprecated property for backword compatibility with existing implementations that didn't use dcterms:publisher

Closes #21, closes #73, closes #311 
