### PR TITLE
Add a SuperLinter config

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -47,3 +47,6 @@
             env:
               VALIDATE_ALL_CODEBASE: true
               VALIDATE_MD: true
+              VALIDATE_XML: true
+              VALIDATE_YAML: true
+              VALIDATE_JSON: true

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,0 +1,49 @@
+---
+    ###########################
+    ###########################
+    ## Linter GitHub Actions ##
+    ###########################
+    ###########################
+    name: Lint Code Base
+
+    #
+    # Documentation:
+    # https://help.github.com/en/articles/workflow-syntax-for-github-actions
+    #
+
+    #############################
+    # Start the job on all push #
+    #############################
+    on:
+      push:
+        branches-ignore:
+          - 'master'
+
+    ###############
+    # Set the Job #
+    ###############
+    jobs:
+      build:
+        # Name the Job
+        name: Lint Code Base
+        # Set the agent to run on
+        runs-on: ubuntu-latest
+
+        ##################
+        # Load all steps #
+        ##################
+        steps:
+          ##########################
+          # Checkout the code base #
+          ##########################
+          - name: Checkout Code
+            uses: actions/checkout@master
+
+          ################################
+          # Run Linter against code base #
+          ################################
+          - name: Lint Code Base
+            uses: github/super-linter@v2.0.0
+            env:
+              VALIDATE_ALL_CODEBASE: true
+              VALIDATE_MD: true

--- a/README.md
+++ b/README.md
@@ -40,14 +40,14 @@ running AJAX requests on local filesystem). With Python 3 installed:
     cd docs/
     python3 -m http.server 8000 --bind 127.0.0.1
 
-Now you can browse all specs via `http://localhost:8000/`. For an even better
+Now you can browse all specs via <http://localhost:8000/>. For an even better
 experience, install Browsersync (`npm i -g browser-sync`) and run it the
 following way:
 
     browser-sync start --config bs-config.js
 
-Now you can browse all specs via `http://localhost:8000/`. **Anytime you save a spec
-file, every browser tab where this file is opened will be reloaded
+Now you can browse all specs via <http://localhost:8000/>. **Anytime you save a
+spec file, every browser tab where this file is opened will be reloaded
 automatically.**
 
 ## Contributions
@@ -64,6 +64,7 @@ a plugin or copying the settings manually. Make sure your lines are wrapped!
 > Pro tip: Atom editor does all of this automatically when you install an
 > Editorconfig for it. Highly recommended. It works even better in a setup with
 > Browsersync described in the section above.
+
 
 > **Warning!** Eclipse, VS Code do not support the wrapping configuration
 > setting from Editorconfig. You should manually configure your editor and ensure

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ a plugin or copying the settings manually. Make sure your lines are wrapped!
 > Editorconfig for it. Highly recommended. It works even better in a setup with
 > Browsersync described in the section above.
 
+<!-- -->
 
 > **Warning!** Eclipse, VS Code do not support the wrapping configuration
 > setting from Editorconfig. You should manually configure your editor and ensure

--- a/README.md
+++ b/README.md
@@ -40,13 +40,13 @@ running AJAX requests on local filesystem). With Python 3 installed:
     cd docs/
     python3 -m http.server 8000 --bind 127.0.0.1
 
-Now you can browse all specs via http://localhost:8000/. For an even better
+Now you can browse all specs via `http://localhost:8000/`. For an even better
 experience, install Browsersync (`npm i -g browser-sync`) and run it the
 following way:
 
     browser-sync start --config bs-config.js
 
-Now you can browse all specs via http://localhost:8000/. **Anytime you save a spec
+Now you can browse all specs via `http://localhost:8000/`. **Anytime you save a spec
 file, every browser tab where this file is opened will be reloaded
 automatically.**
 
@@ -55,19 +55,19 @@ automatically.**
 Read [how to contribute to the OSLC Open
 Project](https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md).
 
-**Call details: https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md#online-meetings**
+**See [the call details](https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md#online-meetings) for instructions how to join our weekly calls.**
 
 For this repository particularly, please ensure that your editor respects the
 [Editorconfig](https://editorconfig.org/#download) settings either by installing
 a plugin or copying the settings manually. Make sure your lines are wrapped!
 
 > Pro tip: Atom editor does all of this automatically when you install an
-Editorconfig for it. Highly recommended. It works even better in a setup with
-Browsersync described in the section above.
+> Editorconfig for it. Highly recommended. It works even better in a setup with
+> Browsersync described in the section above.
 
 > **Warning!** Eclipse, VS Code do not support the wrapping configuration
-setting from Editorconfig. You should manually configure your editor and ensure
-the lines are wrapped.
+> setting from Editorconfig. You should manually configure your editor and ensure
+> the lines are wrapped.
 
 ## Licensing
 


### PR DESCRIPTION
See https://github.blog/2020-06-18-introducing-github-super-linter-one-linter-to-rule-them-all/

Enabled for:

- Markdown files
- YAML files
- XML files
- JSON files