### PR TITLE
Fix warnings in vocabs and shapes

### DIFF
--- a/specs/am/architecture-management-shapes.ttl
+++ b/specs/am/architecture-management-shapes.ttl
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 @prefix dcterms:    <http://purl.org/dc/terms/> .
-@prefix foaf:       <http://xmlns.com/foaf/0.1/> .
-@prefix ldp:        <http://www.w3.org/ns/ldp#> .
 @prefix oslc:       <http://open-services.net/ns/core#> .
 @prefix rdf:        <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:       <http://www.w3.org/2000/01/rdf-schema#> .
@@ -48,7 +46,7 @@ resource like a UML Class, Use Case, or Business Process Diagram."""^^rdf:XMLLit
         <#serviceProvider>,
         <#instanceShape>,
 
-        # Common link types 
+        # Common link types
         <#derives>,
         <#elaborates>,
         <#refine>,
@@ -214,8 +212,8 @@ type that could be used in hover help or other areas of the UI where the user wa
     oslc:propertyDefinition jazz_am:derives  ;
     oslc:range oslc:Any ;
     oslc:occurs oslc:Zero-or-many;
-    dcterms:description """The resource that derives from another resource originated from or is 
-significantly influenced by the referenced resource. For example a model element derives from a 
+    dcterms:description """The resource that derives from another resource originated from or is
+significantly influenced by the referenced resource. For example a model element derives from a
 requirement."""^^rdf:XMLLiteral ;
     oslc:valueType oslc:Resource ;
     oslc:representation oslc:Reference .
@@ -234,7 +232,7 @@ requirement."""^^rdf:XMLLiteral ;
     oslc:propertyDefinition jazz_am:refine  ;
     oslc:range oslc:Any ;
     oslc:occurs oslc:Zero-or-many;
-    dcterms:description """TThe target is a refinement of the source. (e.g. a use case scenario 
+    dcterms:description """TThe target is a refinement of the source. (e.g. a use case scenario
 might be a refinement of a textual requirement that describes the interaction)."""^^rdf:XMLLiteral ;
     oslc:valueType oslc:Resource ;
     oslc:representation oslc:Reference .
@@ -253,7 +251,7 @@ might be a refinement of a textual requirement that describes the interaction)."
     oslc:propertyDefinition jazz_am:satisfy  ;
     oslc:range oslc:Any ;
     oslc:occurs oslc:Zero-or-many;
-    dcterms:description """The model element satisfies the requirement (e.g. The use case 
+    dcterms:description """The model element satisfies the requirement (e.g. The use case
 satisfies a functional requirement)."""^^rdf:XMLLiteral ;
     oslc:valueType oslc:Resource ;
     oslc:representation oslc:Reference .
@@ -263,7 +261,7 @@ satisfies a functional requirement)."""^^rdf:XMLLiteral ;
     oslc:propertyDefinition jazz_am:trace  ;
     oslc:range oslc:Any ;
     oslc:occurs oslc:Zero-or-many;
-    dcterms:description """The model element has a trace to the requirement (e.g. An attribute 
+    dcterms:description """The model element has a trace to the requirement (e.g. An attribute
 or its value are traced to a requirement)."""^^rdf:XMLLiteral ;
     oslc:valueType oslc:Resource ;
     oslc:representation oslc:Reference .

--- a/specs/am/architecture-management-vocab.ttl
+++ b/specs/am/architecture-management-vocab.ttl
@@ -14,12 +14,9 @@
 
 @prefix dcterms:     <http://purl.org/dc/terms/> .
 @prefix owl:         <http://www.w3.org/2002/07/owl#> .
-@prefix oslc:        <http://open-services.net/ns/core#> .
 @prefix rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix vann:        <http://purl.org/vocab/vann/> .
-@prefix vs:          <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix xsd:         <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix oslc_am:    <http://open-services.net/ns/am#> .
 @prefix jazz_am:    <http://jazz.net/ns/dm/linktypes#> .
@@ -27,7 +24,7 @@
 # The ontology
 
 oslc_am:
-    a                              owl:Ontology ;
+    a                    owl:Ontology ;
     rdfs:label           "Architecture Management(AM)" ;
     dcterms:description  "All vocabulary URIs defined in the OSLC Architecture Management (AM) namespace."^^rdf:XMLLiteral ;
     dcterms:title        "The OSLC Architecture Management(AM) Vocabulary" ;
@@ -48,7 +45,7 @@ oslc_am:LinkType
         rdfs:isDefinedBy  oslc_am: ;
         rdfs:label        "Link Type" .
 
-# Link properties that are in common use. 
+# Link properties that are in common use.
 
 jazz_am:trace
       a       rdf:Property ;

--- a/specs/cm/change-mgt-shapes.ttl
+++ b/specs/cm/change-mgt-shapes.ttl
@@ -20,8 +20,6 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
 @prefix oslc_rm: <http://open-services.net/ns/rm#> .
-@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#>.
 
 
 <#ChangeRequestShape> a oslc:ResourceShape ;
@@ -279,16 +277,6 @@
         oslc:valueType           oslc:AnyResource ;
         dcterms:description      "The related parent change requests of the subject change request. Establishes a parent/child relationship between change requests."^^rdf:XMLLiteral ;
         dcterms:title            "Parent of Change Request" .
-
-<#affectedByDefect>  a           oslc:Property ;
-        oslc:name                "affectedByDefect" ;
-        oslc:occurs              oslc:Zero-or-many ;
-        oslc:propertyDefinition  oslc_cm:affectedByDefect ;
-        oslc:range               oslc_cm:Defect ;
-        oslc:representation      oslc:Reference ;
-        oslc:valueType           oslc:Resource ;
-        dcterms:description      "Change request is affected by a reported defect. It is likely that the target resource will be an <code>oslc_cm:Defect</code> but that is not necessarily the case."^^rdf:XMLLiteral ;
-        dcterms:title            "Affected by Defect" .
 
 <#affectedByDefect>  a           oslc:Property ;
         oslc:name                "affectedByDefect" ;

--- a/specs/cm/change-mgt-vocab.ttl
+++ b/specs/cm/change-mgt-vocab.ttl
@@ -22,7 +22,6 @@
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix vs: <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 @base <https://tools.oasis-open.org/version-control/svn/oslc-ccm/trunk/specs/change-mgt/change-mgt-vocab.ttl>.
 

--- a/specs/core/core-shapes.ttl
+++ b/specs/core/core-shapes.ttl
@@ -14,12 +14,10 @@
 
 @prefix :      <http://open-services.net/ns/core/shapes/3.0/#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix ldp:   <http://www.w3.org/ns/ldp#> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix prov:  <http://www.w3.org/ns/prov#> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc:  <http://open-services.net/ns/core#> .
 

--- a/specs/perfmon/performance-monitoring-vocab.ttl
+++ b/specs/perfmon/performance-monitoring-vocab.ttl
@@ -1,4 +1,4 @@
-@prefix qudt:  <http://qudt.org/1.1/schema/qudt> .
+@prefix qudt:  <http://qudt.org/1.1/schema/qudt#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .

--- a/specs/qm/quality-management-shapes.ttl
+++ b/specs/qm/quality-management-shapes.ttl
@@ -12,19 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-@prefix process: <http://jazz.net/ns/process#> .
-@prefix owl:   <http://www.w3.org/2002/07/owl#> .
 @prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
-@prefix skos:  <http://www.w3.org/2004/02/skos/core#> .
-@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix oslc_config: <http://open-services.net/ns/config#> .
 @prefix oslc_rm: <http://open-services.net/ns/rm#> .
 @prefix oslc:  <http://open-services.net/ns/core#> .
 @prefix oslc_qm: <http://open-services.net/ns/qm#> .
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix xml:   <http://www.w3.org/XML/1998/namespace> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
-@prefix rqm_process: <http://jazz.net/xmlns/prod/jazz/rqm/process/1.0/> .
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc_cm: <http://open-services.net/ns/cm#> .
 

--- a/specs/qm/quality-management-vocab.ttl
+++ b/specs/qm/quality-management-vocab.ttl
@@ -17,7 +17,6 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix vann: <http://purl.org/vocab/vann/> .
-@prefix oslc_qm: <http://open-services.net/ns/qm#> .
 
 
 <http://open-services.net/ns/qm#>

--- a/specs/recon/reconciliation-vocab.ttl
+++ b/specs/recon/reconciliation-vocab.ttl
@@ -5,7 +5,6 @@
 @prefix oslc_asset: <http://open-services.net/ns/asset#> .
 @prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix crtv:  <http://open-services.net/ns/crtv#> .
-@prefix oslc:  <http://open-services.net/ns/core#> .
 
 crtv:instancePath  a      rdf:Property ;
         rdfs:comment      "The directory where the files for this SoftwareServer are stored." ;

--- a/specs/recon/reconciliation.ttl
+++ b/specs/recon/reconciliation.ttl
@@ -5,7 +5,6 @@
 @prefix oslc_asset: <http://open-services.net/ns/asset#> .
 @prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix crtv:  <http://open-services.net/ns/crtv#> .
-@prefix oslc:  <http://open-services.net/ns/core#> .
 
 crtv:instancePath  a      rdf:Property ;
         rdfs:comment      "The directory where the files for this SoftwareServer are stored." ;

--- a/specs/rm/requirements-management-shapes.ttl
+++ b/specs/rm/requirements-management-shapes.ttl
@@ -13,11 +13,8 @@
 # limitations under the License.
 
 @prefix dcterms:        <http://purl.org/dc/terms/> .
-@prefix foaf:           <http://xmlns.com/foaf/0.1/> .
-@prefix ldp:            <http://www.w3.org/ns/ldp#> .
 @prefix oslc:           <http://open-services.net/ns/core#> .
 @prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix oslc_rm:       <http://open-services.net/ns/rm#> .

--- a/specs/rm/requirements-management-vocab.ttl
+++ b/specs/rm/requirements-management-vocab.ttl
@@ -16,13 +16,10 @@
 
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix owl:   <http://www.w3.org/2002/07/owl#> .
-@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix vann:  <http://purl.org/vocab/vann/> .
-@prefix vs:    <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
 @prefix oslc_rm: <http://open-services.net/ns/rm#> .
-@prefix oslc:  <http://open-services.net/ns/core#> .
 
 oslc_rm:  a                            owl:Ontology ;
         rdfs:label                     "Requirements Management(RM)" ;

--- a/specs/rm/rm_jra.ttl
+++ b/specs/rm/rm_jra.ttl
@@ -2,7 +2,6 @@
 @prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
-@prefix oslc:  <http://open-services.net/ns/core#> .
 
 <http://open-services.net/ns/rm#>
         a                    owl:Ontology ;

--- a/templates/domain-name-shapes.ttl
+++ b/templates/domain-name-shapes.ttl
@@ -1,9 +1,7 @@
 @prefix dcterms:        <http://purl.org/dc/terms/> .
 @prefix foaf:           <http://xmlns.com/foaf/0.1/> .
-@prefix ldp:            <http://www.w3.org/ns/ldp#> .
 @prefix oslc:           <http://open-services.net/ns/core#> .
 @prefix rdf:            <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
-@prefix rdfs:           <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix xsd:            <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix oslc_xxx:       <http://open-services.net/ns/xxx#> .

--- a/templates/domain-name-vocab.ttl
+++ b/templates/domain-name-vocab.ttl
@@ -2,12 +2,9 @@
 
 @prefix dcterms:     <http://purl.org/dc/terms/> .
 @prefix owl:         <http://www.w3.org/2002/07/owl#> .
-@prefix oslc:        <http://open-services.net/ns/core#> .
 @prefix rdf:         <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:        <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix vann:        <http://purl.org/vocab/vann/> .
-@prefix vs:          <http://www.w3.org/2003/06/sw-vocab-status/ns#> .
-@prefix xsd:         <http://www.w3.org/2001/XMLSchema#> .
 
 @prefix oslc_xxx:    <http://open-services.net/ns/xxx#> .
 


### PR DESCRIPTION
Fix warnings from XTurtle - unused prefixes, things declared twice
Also fixes issue #345.