### PR TITLE
Final touches to the QM spec before publication

### DIFF
--- a/specs/qm/quality-management-shapes.html
+++ b/specs/qm/quality-management-shapes.html
@@ -131,6 +131,12 @@
             companyURL: "http://www.ibm.com",
           },
           {
+            name: "Andrii Berezovskyi",
+            mailto: "andriib@kth.se",
+            company: "KTH",
+            companyURL: "https://www.kth.se/en",
+          },
+          {
             name: "Gray Bachelor",
             mailto: "gray_bachelor@uk.ibm.com",
             company: "IBM",

--- a/specs/qm/quality-management-shapes.html
+++ b/specs/qm/quality-management-shapes.html
@@ -9,7 +9,7 @@
     />
 
     <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.15/builds/respec-oasis-common.min.js"
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.17/builds/respec-oasis-common.min.js"
       async
       class="remove"
     ></script>
@@ -26,16 +26,16 @@
       }
 
       var respecConfig = {
-        shortName: "quality-management-vocab",
+        shortName: "quality-management-shapes",
         specStatus: status,
         revision: revision.toString().padStart(2, "0"),
         // publishDate:  "2019-11-14",
         previousPublishDate: "2019-11-14",
         previousMaturity: "PSD",
 
-        thisVersion: thisBase + "quality-management-vocab.html",
+        thisVersion: thisBase + "quality-management-shapes.html",
         prevVersion: null,
-        latestVersion: oasisBase + "quality-management-vocab.html",
+        latestVersion: oasisBase + "quality-management-shapes.html",
         latestSpecVersion: "https://open-services.net/spec/qm/latest",
         edDraftURI: "https://open-services.net/spec/qm/latest-draft",
 
@@ -107,7 +107,7 @@
         },
 
         // the document's citation label
-        citationLabel: "OSLC-qm-2.1-Part2",
+        citationLabel: "OSLC-qm-2.1-Part3",
         license: "cc-by-4",
 
         additionalLicenses: [
@@ -302,54 +302,6 @@
           data-include-format="html"
         ></div>
       </section>
-    </section>
-
-    <section class="appendix informative" id="history">
-      <h2>Change History</h2>
-      <table border="1" cellspacing="0" cellpadding="0">
-        <tr>
-          <td
-            width="103"
-            valign="top"
-            style="width: 77.4pt; border: solid windowtext 1pt; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Revision</b>
-          </td>
-          <td
-            width="96"
-            valign="top"
-            style="width: 1in; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Date</b>
-          </td>
-          <td
-            width="144"
-            valign="top"
-            style="width: 1.5in; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Editor</b>
-          </td>
-          <td
-            width="295"
-            valign="top"
-            style="width: 221.4pt; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Changes Made</b>
-          </td>
-        </tr>
-        <tr>
-          <td>01</td>
-          <td>07/06/2016</td>
-          <td>Jim Amsden</td>
-          <td>Initial CSPRD01</td>
-        </tr>
-        <tr>
-          <td>02</td>
-          <td>08/08/2018</td>
-          <td>Gray Bachelor</td>
-          <td>Minor edits and checks for V2.1</td>
-        </tr>
-      </table>
     </section>
   </body>
 </html>

--- a/specs/qm/quality-management-shapes.html
+++ b/specs/qm/quality-management-shapes.html
@@ -309,5 +309,14 @@
         ></div>
       </section>
     </section>
+
+    <section id="conformance">
+      <h2>Conformance</h2>
+      <p>
+        Quality Management servers MUST follow the constraints defined here where required, and with the meanings
+        defined here.
+      </p>
+      <p>Quality Management servers MAY provide additional constraints for specific purposes.</p>
+    </section>
   </body>
 </html>

--- a/specs/qm/quality-management-shapes.ttl
+++ b/specs/qm/quality-management-shapes.ttl
@@ -21,11 +21,11 @@
 @prefix foaf:  <http://xmlns.com/foaf/0.1/> .
 @prefix oslc_cm: <http://open-services.net/ns/cm#> .
 
-@prefix : <https://open-services.net/ns/qm/shapes/2.1/#> .
+@prefix : <https://open-services.net/ns/qm/shapes/2.1#> .
 
 : a oslc:ResourceShapeConstraints;
-  dcterms:title "OSLC QM Resource Shape Constraints" ;
-  rdfs:label "OSLC QM Resource Shape Constraints" ;
+  dcterms:title "OSLC Quality Management (QM) Resource Shape Constraints" ;
+  rdfs:label "OSLC Quality Management (QM) Resource Shape Constraints" ;
   dcterms:description "Resource Shape Constraints defined in the OSLC QM 2.1 specification."^^rdf:XMLLiteral ;
   dcterms:publisher <https://open-services.net/about/> ;
   dcterms:license <http://www.apache.org/licenses/LICENSE-2.0> ;

--- a/specs/qm/quality-management-spec.html
+++ b/specs/qm/quality-management-spec.html
@@ -11,7 +11,7 @@ tasks and relationships between those and related resources such as requirements
     />
 
     <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.15/builds/respec-oasis-common.min.js"
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.17/builds/respec-oasis-common.min.js"
       async
       class="remove"
     ></script>
@@ -218,6 +218,12 @@ tasks and relationships between those and related resources such as requirements
             mailto: "jamsden@us.ibm.com",
             company: "IBM",
             companyURL: "https://www.ibm.com",
+          },
+          {
+            name: "Andrii Berezovskyi",
+            mailto: "andriib@kth.se",
+            company: "KTH",
+            companyURL: "https://www.kth.se/en",
           },
           {
             name: "Gray Bachelor",
@@ -630,7 +636,7 @@ tasks and relationships between those and related resources such as requirements
             >
             to maintain integrations with the legacy applications.
           </li>
-          <li>
+          <li class="conformance">
             The Atom Syndication Format XML representation SHOULD use RDF/XML representation without restrictions for
             the <code>atom:content</code> entries representing the resource representations.
           </li>
@@ -997,7 +1003,78 @@ tasks and relationships between those and related resources such as requirements
         </tr>
       </table>
     </section>
-    <!-- </section> -->
+
+    <section class="appendix informative" id="history">
+      <h2>Change History</h2>
+      <table border="1" cellspacing="0" cellpadding="0">
+        <tr>
+          <td
+            width="103"
+            valign="top"
+            style="width: 77.4pt; border: solid windowtext 1pt; padding: 0in 5.4pt 0in 5.4pt;"
+          >
+            <b>Revision</b>
+          </td>
+          <td
+            width="96"
+            valign="top"
+            style="width: 1in; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
+          >
+            <b>Date</b>
+          </td>
+          <td
+            width="144"
+            valign="top"
+            style="width: 1.5in; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
+          >
+            <b>Editor</b>
+          </td>
+          <td
+            width="295"
+            valign="top"
+            style="width: 221.4pt; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
+          >
+            <b>Changes Made</b>
+          </td>
+        </tr>
+        <tr>
+          <td>CSPRD01 (not published)</td>
+          <td>2018-08-08</td>
+          <td>Jim Amsden and Gray Bachelor</td>
+          <td>
+            <ul>
+              <li>Initial CSPRD01 for V2.1</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>PSD02</td>
+          <td>2019-11-14</td>
+          <td>Andrii Berezovskyi</td>
+          <td>
+            <ul>
+              <li>Migration to the OASIS OSLC Open Project</li>
+              <li>Publication of the vocabulary and shapes</li>
+            </ul>
+          </td>
+        </tr>
+        <tr>
+          <td>TBD</td>
+          <td>TBA</td>
+          <td>Andrii Berezovskyi</td>
+          <td>
+            <ul>
+              <li>
+                Split vocabulary and shapes parts as well as reference machine-readable definitions as normative parts
+                of the spec
+              </li>
+              <li>Change shapes base URI</li>
+              <li>Add shapes metadata</li>
+            </ul>
+          </td>
+        </tr>
+      </table>
+    </section>
 
     <section class="appendix informative">
       <h2>Acknowledgements</h2>

--- a/specs/qm/quality-management-vocab.html
+++ b/specs/qm/quality-management-vocab.html
@@ -131,6 +131,12 @@
             companyURL: "http://www.ibm.com",
           },
           {
+            name: "Andrii Berezovskyi",
+            mailto: "andriib@kth.se",
+            company: "KTH",
+            companyURL: "https://www.kth.se/en",
+          },
+          {
             name: "Gray Bachelor",
             mailto: "gray_bachelor@uk.ibm.com",
             company: "IBM",

--- a/specs/qm/quality-management-vocab.html
+++ b/specs/qm/quality-management-vocab.html
@@ -9,7 +9,7 @@
     />
 
     <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.15/builds/respec-oasis-common.min.js"
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.17/builds/respec-oasis-common.min.js"
       async
       class="remove"
     ></script>
@@ -237,54 +237,6 @@
         data-include-replace="true"
         data-include-format="html"
       ></div>
-    </section>
-
-    <section class="appendix informative" id="history">
-      <h2>Change History</h2>
-      <table border="1" cellspacing="0" cellpadding="0">
-        <tr>
-          <td
-            width="103"
-            valign="top"
-            style="width: 77.4pt; border: solid windowtext 1pt; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Revision</b>
-          </td>
-          <td
-            width="96"
-            valign="top"
-            style="width: 1in; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Date</b>
-          </td>
-          <td
-            width="144"
-            valign="top"
-            style="width: 1.5in; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Editor</b>
-          </td>
-          <td
-            width="295"
-            valign="top"
-            style="width: 221.4pt; border: solid windowtext 1pt; border-left: none; padding: 0in 5.4pt 0in 5.4pt;"
-          >
-            <b>Changes Made</b>
-          </td>
-        </tr>
-        <tr>
-          <td>01</td>
-          <td>07/06/2016</td>
-          <td>Jim Amsden</td>
-          <td>Initial CSPRD01</td>
-        </tr>
-        <tr>
-          <td>02</td>
-          <td>08/08/2018</td>
-          <td>Gray Bachelor</td>
-          <td>Minor edits and checks for V2.1</td>
-        </tr>
-      </table>
     </section>
   </body>
 </html>

--- a/specs/qm/quality-management-vocab.html
+++ b/specs/qm/quality-management-vocab.html
@@ -244,5 +244,16 @@
         data-include-format="html"
       ></div>
     </section>
+
+    <section id="conformance">
+      <h2>Conformance</h2>
+      <p>
+        Quality Management servers MUST use the vocabulary terms defined here where required, and with the meanings
+        defined here.
+      </p>
+      <p>
+        Quality Management servers MAY augment this vocabulary with additional classes, properties, and individuals.
+      </p>
+    </section>
   </body>
 </html>

--- a/specs/qm/quality-management-vocab.ttl
+++ b/specs/qm/quality-management-vocab.ttl
@@ -22,13 +22,14 @@
 
 <http://open-services.net/ns/qm#>
         a                    owl:Ontology ;
-        dcterms:title        "The OSLC Quality Management(QM) Vocabulary" ;
-        rdfs:label           "Quality Management(QM)" ;
+        dcterms:title        "OSLC Quality Management (QM) Vocabulary" ;
+        rdfs:label           "OSLC Quality Management (QM) Vocabulary" ;
         dcterms:description  "All vocabulary URIs defined in the OSLC Quality Management (QM) namespace."^^rdf:XMLLiteral ;
         vann:preferredNamespacePrefix "oslc_qm" ;
         dcterms:publisher <https://open-services.net/about/> ;
         dcterms:license <http://www.apache.org/licenses/LICENSE-2.0> ;
-        dcterms:modified "2020-06-12"^^<http://www.w3.org/2001/XMLSchema#date> ;
+        # TODO add before publication
+        # dcterms:issued "2020-07-30"^^<http://www.w3.org/2001/XMLSchema#date> ;
         rdfs:seeAlso <https://github.com/oslc-op/oslc-specs/blob/master/specs/qm/quality-management-vocab.ttl> ;
         # TODO replace with a reference to the OASIS Docs archive as part of the publication PR
         dcterms:source <https://github.com/oslc-op/oslc-specs/blob/master/specs/qm/quality-management-vocab.ttl> ;


### PR DESCRIPTION
- Upgrade to ReSpec 2.1.17
- Remove trailing slash from the shapes prefix
- Update title and label for vocab and shapes
- Update change history
- Fix a RFC term outside conformance clause warning