### PR TITLE
fixes #387 - Allow the -q option to control unusedVocabulary

### DIFF
--- a/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/CrossCheck.java
+++ b/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/CrossCheck.java
@@ -4,11 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.ResIterator;
-import org.apache.jena.rdf.model.Resource;
-import org.apache.jena.rdf.model.ResourceFactory;
-import org.apache.jena.rdf.model.StmtIterator;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 
@@ -101,7 +97,7 @@ public class CrossCheck
         {
             if (!vocab.getValue())
             {
-                resultModel.getSummary().addProperty(Terms.unusedVocabulary, vocab.getKey());
+                resultModel.addSummaryIssue(Terms.unusedVocabulary, vocab.getKey());
             }
         }
 
@@ -109,7 +105,7 @@ public class CrossCheck
         {
             if (!term.getValue())
             {
-                resultModel.getSummary().addProperty(Terms.unusedTerm, term.getKey());
+                resultModel.addSummaryIssue(Terms.unusedTerm, term.getKey());
             }
         }
 
@@ -117,13 +113,13 @@ public class CrossCheck
         {
             if (!term.getValue())
             {
-                resultModel.getSummary().addProperty(Terms.undefinedTerm, term.getKey());
+                resultModel.addSummaryIssue(Terms.undefinedTerm, term.getKey());
             }
         }
     }
 
 
-    /**
+	/**
      * Print a list of all vocabulary terms defined.
      */
     public void printVocabTerms()

--- a/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/ResultModel.java
+++ b/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/ResultModel.java
@@ -1,14 +1,8 @@
 package net.open_services.scheck.shapechecker;
 
-import java.util.Calendar;
-import java.util.HashSet;
-import java.util.Set;
+import java.util.*;
 
-import org.apache.jena.rdf.model.Literal;
-import org.apache.jena.rdf.model.Model;
-import org.apache.jena.rdf.model.ModelFactory;
-import org.apache.jena.rdf.model.RDFNode;
-import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.*;
 import org.apache.jena.vocabulary.DCTerms;
 import org.apache.jena.vocabulary.RDF;
 
@@ -131,17 +125,6 @@ public class ResultModel
 
 
     /**
-     * Get the summary resource in the result model.
-     * @return the result model
-     */
-    @javax.annotation.CheckReturnValue
-    public Resource getSummaryResource()
-    {
-        return summaryResource;
-    }
-
-
-    /**
      * Create an anonymous outer node to hold results for a vocabulary or shape.
      * @param type the type of the outer node ({@code VocabResult} or {@code ShapesResult})
      * @return the resource created
@@ -176,7 +159,7 @@ public class ResultModel
      */
     public void suppressIssue(String name)
     {
-        Terms.findIssue(name).ifPresent(r -> suppressedIssues.add(r));
+    	Terms.findIssue(name).ifPresent(r -> suppressedIssues.add(r));
     }
 
 
@@ -250,7 +233,7 @@ public class ResultModel
     }
 
 
-    /**
+	/**
      * Get the summary resource.
      * @return the summary resource
      */
@@ -259,7 +242,23 @@ public class ResultModel
     {
         return summaryResource;
     }
+
+
     /**
+     * Description of addSummaryIssue.
+     * @param type the type of the issue
+     * @param resource the resource (vocabulary, shape, term) for the issue
+     */
+    public void addSummaryIssue(Property type, Resource resource)
+	{
+		if (!suppressedIssues.contains(type))
+		{
+			getSummary().addProperty(type, resource);
+		}
+	}
+
+
+	/**
      * Add counts of each issue severity.
      * @param debug the current debug level
      * @return the number of errors found.

--- a/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/Terms.java
+++ b/tools/ShapeChecker/src/main/java/net/open_services/scheck/shapechecker/Terms.java
@@ -34,9 +34,9 @@ import static net.open_services.scheck.annotations.IssueSeverity.*;
 		})
 public final class Terms
 {
-    private static final String checkerNS          = "http://open-services.net/ns/scheck#";
+    private static final String checkerNS         = "http://open-services.net/ns/scheck#";
 
-    private static Map<String, Resource> issueMap  = new HashMap<>();
+    private static Map<String, Resource> termMap  = new HashMap<>();
 
     /**
      * No instantiation.
@@ -51,21 +51,32 @@ public final class Terms
      */
     public static Optional<Resource> findIssue(String name)
     {
-        return Optional.ofNullable(Terms.issueMap.get(name));
+        return Optional.ofNullable(Terms.termMap.get(name));
+    }
+
+
+    private static void addTerm(String local, Resource resource)
+    {
+        if (termMap.put(local, resource) != null)
+        {
+        	throw new RuntimeException("Duplicate term name found: "+local);
+        }
     }
 
 
     private static Resource resource(String local)
     {
         Resource resource = ResourceFactory.createResource(checkerNS + local);
-        issueMap.put(local, resource);
+        addTerm(local, resource);
         return resource;
     }
 
 
     private static Property property(String local)
     {
-        return ResourceFactory.createProperty(checkerNS, local);
+        Property property = ResourceFactory.createProperty(checkerNS, local);
+        addTerm(local, property);
+		return property;
     }
 
 


### PR DESCRIPTION
@berezovskyi  - you can now suppress the ShapeChecker unused vocabulary warning with `-q unusedVocabulary`.