### PR TITLE
Add vocab term for oslc:cause

### DIFF
--- a/specs/core/core-shapes.ttl
+++ b/specs/core/core-shapes.ttl
@@ -1310,7 +1310,7 @@
                              ] ;
         oslc:property        [ a                        oslc:Property ;
                                oslc:name                "RDF Type" ;
-                               oslc:occurs              oslc:Zero-or-Many ;
+                               oslc:occurs              oslc:Zero-or-many ;
                                oslc:propertyDefinition  rdf:type ;
                                oslc:readOnly            true ;
                                oslc:representation      oslc:Reference ;

--- a/specs/core/core-shapes.ttl
+++ b/specs/core/core-shapes.ttl
@@ -554,7 +554,7 @@
                         ] ;
         oslc:property   [ a                        oslc:Property ;
                           oslc:name                "RDF Type" ;
-                          oslc:occurs              oslc:Zero-or-Many ;
+                          oslc:occurs              oslc:Zero-or-many ;
                           oslc:propertyDefinition  rdf:type ;
                           oslc:readOnly            true ;
                           oslc:representation      oslc:Reference ;

--- a/specs/core/core-shapes.ttl
+++ b/specs/core/core-shapes.ttl
@@ -552,6 +552,15 @@
                           oslc:valueType           xsd:integer ;
                           dcterms:description      "For string datatype properties, the maximum number of characters."^^rdf:XMLLiteral
                         ] ;
+        oslc:property   [ a                        oslc:Property ;
+                          oslc:name                "RDF Type" ;
+                          oslc:occurs              oslc:Zero-or-Many ;
+                          oslc:propertyDefinition  rdf:type ;
+                          oslc:readOnly            true ;
+                          oslc:representation      oslc:Reference ;
+                          oslc:valueType           oslc:Resource ;
+                          dcterms:description      "An OSLC property SHOULD have an RDF type of oslc:Property."^^rdf:XMLLiteral
+                        ] ;
         dcterms:title   "Specifies the name, description, summary, occurrence, value type, allowed values, and several other aspects of the defined property." .
 
 :hidden  a                       oslc:Property ;
@@ -835,6 +844,16 @@
                           oslc:readOnly            true ;
                           oslc:valueType           xsd:string ;
                           dcterms:description      "The HTTP status code reported with the error."^^rdf:XMLLiteral
+                        ] ;
+        oslc:property   [ a                        oslc:Property ;
+                          oslc:name                "cause" ;
+                          oslc:occurs              oslc:Zero-or-many ;
+                          oslc:propertyDefinition  oslc:cause ;
+                          oslc:readOnly            true ;
+                          oslc:representation      oslc:Either ;
+                          oslc:valueType           oslc:AnyResource ;
+                          oslc:range               oslc:Error ;
+                          dcterms:description      "An error that was the cause of this error."^^rdf:XMLLiteral
                         ] ;
         dcterms:title   "OSLC Core Error Shape" .
 
@@ -1288,6 +1307,15 @@
                                oslc:readOnly            true ;
                                oslc:valueType           rdf:XMLLiteral ;
                                dcterms:description      "The summary of this shape."^^rdf:XMLLiteral
+                             ] ;
+        oslc:property        [ a                        oslc:Property ;
+                               oslc:name                "RDF Type" ;
+                               oslc:occurs              oslc:Zero-or-Many ;
+                               oslc:propertyDefinition  rdf:type ;
+                               oslc:readOnly            true ;
+                               oslc:representation      oslc:Reference ;
+                               oslc:valueType           oslc:Resource ;
+                               dcterms:description      "An OSLC resource shape SHOULD have an RDF type of oslc:ResourceShape."^^rdf:XMLLiteral
                              ] ;
         dcterms:description  "A resource should satisfy all the constraints defined by its applicable shapes." ;
         dcterms:title        "A shape resource describes the contents of and constraints on some set of described resources." .

--- a/specs/core/core-vocab.ttl
+++ b/specs/core/core-vocab.ttl
@@ -791,3 +791,9 @@ oslc:ResourceShapeConstraints
   rdfs:isDefinedBy oslc: ;
   rdfs:label "ResourceShapeConstraints" ;
   rdfs:comment "Resource Shape Constraints metadata" .
+  
+oslc:cause
+  a rdf:Property ;
+  rdfs:isDefinedBy oslc: ;
+  rdfs:label "cause" ;
+  rdfs:comment "An error that is a cause of this error." .


### PR DESCRIPTION
@berezovskyi the core shapes TTL already included dcterms:identifier on oslc:Error shape, so I closed that issue.

fixes #473; fixes #465