### PR TITLE
These address publishing issues for PSD01

### DIFF
--- a/specs/trs/tracked-resource-set-shapes.html
+++ b/specs/trs/tracked-resource-set-shapes.html
@@ -19,7 +19,7 @@
       var oasisBase = "https://docs.oasis-open-projects.org/oslc-op/trs/v3.0";
       var rev = "01";
       var thisBase = wdBase;
-      if (status != "WD") {
+      if (status !== "WD") {
         thisBase = oasisBase + "/" + status.toLowerCase() + rev;
       }
       var respecConfig = {
@@ -28,6 +28,9 @@
         specStatus: status,
         revision: rev,
         thisVersion: thisBase + filePath,
+        latestVersion: oasisBase + filePath,
+        latestSpecVersion: "https://open-services.net/spec/trs/latest",
+        edDraftURI: "https://open-services.net/spec/trs/latest-draft",
         publishDate: "2021-08-26T12:00Z",
         maxTocLevel: 3,
         noConformanceTable: 1,
@@ -71,23 +74,23 @@
 
         // Other parts of multi-part spec
         additionalArtifacts: [
-          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: "tracked-resource-set.html" },
+          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: thisBase+"/tracked-resource-set.html" },
           {
             title: "OSLC TRS Version 3.0. Part 2: Vocabulary",
-            href: "tracked-resource-set-vocab.html",
+            href: thisBase+"/tracked-resource-set-vocab.html",
           },
           {
             title: "OSLC TRS Version 3.0. Part 3: Constraints (this document)",
-            href: "tracked-resource-set-shapes.html",
+            href: thisBase+"/tracked-resource-set-shapes.html",
           },
-          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: "trs-vocab.ttl" },
-          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: "trs-shapes.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase+"/trs-vocab.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: thisBase+"/trs-shapes.ttl" },
         ],
 
         localBiblio: {
           VOCAB: {
             title: "OSLC TRS Version 3.0: Part 3: Machine-readable vocabulary",
-            href: "http://open-services.net/ns/trs",
+            href: thisBase+"/trs-vocab.ttl",
             authors: ["Nick Crossley", "Frank Budinsky"],
             status: "Finalization",
             publisher: "http://open-services.net",

--- a/specs/trs/tracked-resource-set-shapes.html
+++ b/specs/trs/tracked-resource-set-shapes.html
@@ -13,7 +13,7 @@
       class="remove"
     ></script>
     <script class="remove">
-      var filePath = "/tracked-resource-set-vocab.html";
+      var filePath = "/tracked-resource-set-shapes.html";
       var status = "PSD";
       var wdBase = "https://oslc-op.github.io/oslc-specs/specs/trs";
       var oasisBase = "https://docs.oasis-open-projects.org/oslc-op/trs/v3.0";

--- a/specs/trs/tracked-resource-set-shapes.html
+++ b/specs/trs/tracked-resource-set-shapes.html
@@ -74,23 +74,26 @@
 
         // Other parts of multi-part spec
         additionalArtifacts: [
-          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: thisBase+"/tracked-resource-set.html" },
+          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: thisBase + "/tracked-resource-set.html" },
           {
             title: "OSLC TRS Version 3.0. Part 2: Vocabulary",
-            href: thisBase+"/tracked-resource-set-vocab.html",
+            href: thisBase + "/tracked-resource-set-vocab.html",
           },
           {
             title: "OSLC TRS Version 3.0. Part 3: Constraints (this document)",
-            href: thisBase+"/tracked-resource-set-shapes.html",
+            href: thisBase + "/tracked-resource-set-shapes.html",
           },
-          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase+"/trs-vocab.ttl" },
-          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: thisBase+"/trs-shapes.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase + "/trs-vocab.ttl" },
+          {
+            title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes",
+            href: thisBase + "/trs-shapes.ttl",
+          },
         ],
 
         localBiblio: {
           VOCAB: {
             title: "OSLC TRS Version 3.0: Part 3: Machine-readable vocabulary",
-            href: thisBase+"/trs-vocab.ttl",
+            href: thisBase + "/trs-vocab.ttl",
             authors: ["Nick Crossley", "Frank Budinsky"],
             status: "Finalization",
             publisher: "http://open-services.net",

--- a/specs/trs/tracked-resource-set-vocab.html
+++ b/specs/trs/tracked-resource-set-vocab.html
@@ -71,23 +71,26 @@
 
         // Other parts of multi-part spec
         additionalArtifacts: [
-          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: thisBase+"/tracked-resource-set.html" },
+          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: thisBase + "/tracked-resource-set.html" },
           {
             title: "OSLC TRS Version 3.0. Part 2: Vocabulary (this document)",
-            href: thisBase+"/tracked-resource-set-vocab.html",
+            href: thisBase + "/tracked-resource-set-vocab.html",
           },
           {
             title: "OSLC TRS Version 3.0. Part 3: Constraints",
-            href: thisBase+"/tracked-resource-set-shapes.html",
+            href: thisBase + "/tracked-resource-set-shapes.html",
           },
-          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase+"/trs-vocab.ttl" },
-          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: thisBase+"/trs-shapes.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase + "/trs-vocab.ttl" },
+          {
+            title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes",
+            href: thisBase + "/trs-shapes.ttl",
+          },
         ],
 
         localBiblio: {
           VOCAB: {
             title: "OSLC TRS Version 3.0: Part 3: Machine-readable vocabulary",
-            href: thisBase+"/trs-vocab.ttl",
+            href: thisBase + "/trs-vocab.ttl",
             authors: ["Nick Crossley", "Frank Budinsky"],
             status: "Finalization",
             publisher: "http://open-services.net",

--- a/specs/trs/tracked-resource-set-vocab.html
+++ b/specs/trs/tracked-resource-set-vocab.html
@@ -25,6 +25,9 @@
         specStatus: status,
         revision: rev,
         thisVersion: thisBase + filePath,
+        latestVersion: oasisBase + filePath,
+        latestSpecVersion: "https://open-services.net/spec/trs/latest",
+        edDraftURI: "https://open-services.net/spec/trs/latest-draft",
         publishDate: "2021-08-26T12:00Z",
         maxTocLevel: 3,
         noConformanceTable: 1,
@@ -68,23 +71,23 @@
 
         // Other parts of multi-part spec
         additionalArtifacts: [
-          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: "tracked-resource-set.html" },
+          { title: "OSLC TRS Version 3.0. Part 1: Specification", href: thisBase+"/tracked-resource-set.html" },
           {
             title: "OSLC TRS Version 3.0. Part 2: Vocabulary (this document)",
-            href: "tracked-resource-set-vocab.html",
+            href: thisBase+"/tracked-resource-set-vocab.html",
           },
           {
-            title: "OSLC TRS Version 3.0. Part 3: Constraints ",
-            href: "tracked-resource-set-shapes.html",
+            title: "OSLC TRS Version 3.0. Part 3: Constraints",
+            href: thisBase+"/tracked-resource-set-shapes.html",
           },
-          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: "trs-vocab.ttl" },
-          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: "trs-shapes.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase+"/trs-vocab.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: thisBase+"/trs-shapes.ttl" },
         ],
 
         localBiblio: {
           VOCAB: {
             title: "OSLC TRS Version 3.0: Part 3: Machine-readable vocabulary",
-            href: "http://open-services.net/ns/trs",
+            href: thisBase+"/trs-vocab.ttl",
             authors: ["Nick Crossley", "Frank Budinsky"],
             status: "Finalization",
             publisher: "http://open-services.net",
@@ -104,7 +107,7 @@
       <p>This specification defines a vocabulary for Tracked Resource Sets.</p>
       <p>
         Note that this document is informative; the normative document for the vocabulary is the machine-readable source
-        in [[VOCAB]].
+        in [[!VOCAB]].
       </p>
       <section id="conventions" class="informative" />
       <section id="references">

--- a/specs/trs/tracked-resource-set.html
+++ b/specs/trs/tracked-resource-set.html
@@ -17,7 +17,7 @@
       var oasisBase = "https://docs.oasis-open-projects.org/oslc-op/trs/v3.0";
       var rev = "01";
       var thisBase = wdBase;
-      if (status != "PSD") {
+      if (status !== "WD") {
         thisBase = oasisBase + "/" + status.toLowerCase() + rev;
       }
       var respecConfig = {
@@ -26,6 +26,10 @@
         specStatus: status,
         revision: rev,
         thisVersion: thisBase + filePath,
+        prevVersion: null,
+        latestVersion: oasisBase + filePath,
+        latestSpecVersion: "https://open-services.net/spec/trs/latest",
+        edDraftURI: "https://open-services.net/spec/trs/latest-draft",
         publishDate: "2021-08-26T12:00Z",
         maxTocLevel: 3,
         license: "cc-by-4",
@@ -68,25 +72,21 @@
 
         // Other parts of multi-part spec
         additionalArtifacts: [
-          { title: "OSLC TRS Version 3.0. Part 1: Specification (this document)", href: "tracked-resource-set.html" },
+          { title: "OSLC TRS Version 3.0. Part 1: Specification (this document)", href: thisBase+"/tracked-resource-set.html" },
           {
             title: "OSLC TRS Version 3.0. Part 2: Vocabulary",
-            href: "tracked-resource-set-vocab.html",
+            href: thisBase+"/tracked-resource-set-vocab.html",
           },
           {
-            title: "OSLC TRS Version 3.0. Part 3: Constraints ",
-            href: "tracked-resource-set-shapes.html",
+            title: "OSLC TRS Version 3.0. Part 3: Constraints",
+            href: thisBase+"/tracked-resource-set-shapes.html",
           },
-          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: "trs-vocab.ttl" },
-          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: "trs-shapes.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase+"/trs-vocab.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: thisBase+"/trs-shapes.ttl" },
         ],
 
-        relatedWork: [
-          {
-            title: "OSLC Tracked Resource Set Guidance. Work in progress. Current draft",
-            href: "guidance.html",
-          },
-        ],
+        relatedWork: [],
+        
         localBiblio: {
           OSLCCore2: {
             title: "OSLC Core 2.0",

--- a/specs/trs/tracked-resource-set.html
+++ b/specs/trs/tracked-resource-set.html
@@ -83,7 +83,7 @@
 
         relatedWork: [
           {
-            title: "OSLC Tracked Resource Set Guidance",
+            title: "OSLC Tracked Resource Set Guidance. Work in progress. Current draft",
             href: "guidance.html",
           },
         ],
@@ -97,7 +97,7 @@
           },
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href: "http://tools.oasis-open.org/version-control/svn/oslc-core/specs/oslc-core-v3.html",
+            href: "https://docs.oasis-open-projects.org/oslc-op/core/v3.0/oslc-core.html",
             authors: ["Steve Speicher", "Jim Amsden"],
             publisher: "OASIS",
           },

--- a/specs/trs/tracked-resource-set.html
+++ b/specs/trs/tracked-resource-set.html
@@ -72,21 +72,27 @@
 
         // Other parts of multi-part spec
         additionalArtifacts: [
-          { title: "OSLC TRS Version 3.0. Part 1: Specification (this document)", href: thisBase+"/tracked-resource-set.html" },
+          {
+            title: "OSLC TRS Version 3.0. Part 1: Specification (this document)",
+            href: thisBase + "/tracked-resource-set.html",
+          },
           {
             title: "OSLC TRS Version 3.0. Part 2: Vocabulary",
-            href: thisBase+"/tracked-resource-set-vocab.html",
+            href: thisBase + "/tracked-resource-set-vocab.html",
           },
           {
             title: "OSLC TRS Version 3.0. Part 3: Constraints",
-            href: thisBase+"/tracked-resource-set-shapes.html",
+            href: thisBase + "/tracked-resource-set-shapes.html",
           },
-          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase+"/trs-vocab.ttl" },
-          { title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes", href: thisBase+"/trs-shapes.ttl" },
+          { title: "OSLC TRS Version 3.0: Part 4: Machine-readable RDF Vocabulary", href: thisBase + "/trs-vocab.ttl" },
+          {
+            title: "OSLC TRS Version 3.0: Part 5: Machine-readable Resource Shapes",
+            href: thisBase + "/trs-shapes.ttl",
+          },
         ],
 
         relatedWork: [],
-        
+
         localBiblio: {
           OSLCCore2: {
             title: "OSLC Core 2.0",


### PR DESCRIPTION
I couldn't find any other issues. The guidance.html document should be moved to the oscl-spec/notes folder when it is completed.  We can address that in PS01.