### PR TITLE
Prepare for PN publication

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -43,7 +43,7 @@ jobs:
       # Run Linter against code base #
       ################################
       - name: Lint Code Base
-        uses: github/super-linter@v3
+        uses: github/super-linter@v3.17.0
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_MD: true

--- a/notes/config-primer/config-primer.html
+++ b/notes/config-primer/config-primer.html
@@ -5,26 +5,24 @@
     <meta charset="utf-8" />
     <meta name="description" content="This primer serves as a guide to the concepts in the specification, and through the use of simple examples, explains how versioning and configurations are represented, how and when local configurations and global configurations are used, and lists the elements that an implementation should consider." />
 
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.min.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
       async
       class="remove"
-    ></script>
-    <!-- <script src='http://127.0.0.1:8081/respec-oasis-common.js' async class='remove'></script> -->
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
         shortName: "config-primer",
-        specStatus: "PND",
+        specStatus: "PN",
         revision: "01",
-        // publishDate: "2020-08-27",
-        // previousPublishDate: "2019-11-14",
-        // previousMaturity: "PSD",
+        publishDate: "2021-11-04T18:00Z",
 
-        thisVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        prevVersion: null,
-        latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/notes/config-primer/pn01/config-primer.html",
+        // prevVersion: null,
+        // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
 
         // Other parts of multi-part spec
         additionalArtifacts: [],
@@ -34,24 +32,21 @@
         localBiblio: {
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
             authors: ["Jim Amsden", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCCoreVocab: {
             title: "OSLC Core Vocabulary",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
             authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCShapes: {
             title: "OSLC Resource Shape 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
             authors: ["Arthur Ryman", "Jim Amsden"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",

--- a/notes/config-primer/template.html
+++ b/notes/config-primer/template.html
@@ -5,26 +5,24 @@
     <meta charset="utf-8" />
     <meta name="description" content="$abstract$" />
 
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.min.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
       async
       class="remove"
-    ></script>
-    <!-- <script src='http://127.0.0.1:8081/respec-oasis-common.js' async class='remove'></script> -->
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
         shortName: "config-primer",
-        specStatus: "PND",
+        specStatus: "PN",
         revision: "01",
-        // publishDate: "2020-08-27",
-        // previousPublishDate: "2019-11-14",
-        // previousMaturity: "PSD",
+        publishDate: "2021-11-04T18:00Z",
 
-        thisVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        prevVersion: null,
-        latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/notes/config-primer/pn01/config-primer.html",
+        // prevVersion: null,
+        // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
 
         // Other parts of multi-part spec
         additionalArtifacts: [],
@@ -34,24 +32,21 @@
         localBiblio: {
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
             authors: ["Jim Amsden", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCCoreVocab: {
             title: "OSLC Core Vocabulary",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
             authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCShapes: {
             title: "OSLC Resource Shape 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
             authors: ["Arthur Ryman", "Jim Amsden"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",

--- a/notes/core-3.0-changes/core-3.0-changes.html
+++ b/notes/core-3.0-changes/core-3.0-changes.html
@@ -3,7 +3,10 @@
   <head>
     <title>Summary of changes in OSLC Core 3.0</title>
     <meta charset="utf-8" />
-    <meta name="description" content="This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications." />
+    <meta
+      name="description"
+      content="This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications."
+    />
 
     <!-- <script
       src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
@@ -121,64 +124,164 @@
 
   <body>
     <section id="abstract">
-      <p>This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications.</p>
+      <p>
+        This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes
+        in the specifications.
+      </p>
     </section>
 
     <section id="toc"></section>
     <section id="sotd"></section>
 
     <section id="introduction" class="level2">
-    <h2>Introduction</h2>
-    <p>We are happy to announce a publication of OSLC 3.0, the next generation of the core OSLC specification, as the OASIS Standard. The specification in full can be viewed freely <a href="https://docs.oasis-open-projects.org/oslc-op/core/v3.0/os/oslc-core.html">online</a> and this note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications.</p>
-    <p>The OSLC Core 2.0 evolution from 1.0 strengthened its definition of the use of RESTful HTTP web services and adopted an existing standard-based approach to representing a data model that was flexible and had multiple representation formats, namely RDF. A primary goal of OSLC Core 3.0 was upwards compatibility with OSLC 2.0, preserving the investment in existing implementations. Most OSLC Core 3.0 changes are optional and OSLC 2.0 servers will not be mandated to adopt them to be compliant with 3.0. In most cases, existing OSLC 2.0 clients should be able to consume OSLC 3.0 servers with no changes. This should result in a less disruptive change from 2.0 to 3.0. This document provides a summary of the changes in OSLC Core 3.0 with respect to OSLC Core 2.0.</p>
-    <p>From the standardization point of view, there have been two major changes in OSLC 3.0 that further the openness of OSLC and strengthen its integration value. First, the specification development was moved to OASIS, a vendor-neutral standardization body with a proven track record of assisting in the publication of standards that are widely adopted and further standardized by international bodies like ISO (e.g. <a href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html">MQTT</a>, <a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=office">ODF (ISO/IEC 26300-1:2015)</a>). Throughout the development of the specifications, our member section at OASIS featured as many as <a href="https://web.archive.org/web/20170814105435/http://www.oasis-oslc.org:80/members">16 members</a> before executing a transition to an Open Project that has drastically lowered the bar to <a href="https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md">entry</a>. Second, the OSLC 3.0 specification is now aligned with the <a href="https://www.w3.org/TR/ldp/">Linked Data Platform 1.0</a>, a W3C Recommendation, that was adopted by projects such as <a href="https://solidproject.org/">Solid</a>, focused on decentralizing data storage and spearheaded by Sir Tim Berners-Lee, the founding father of the Web.</p>
+      <h2>Introduction</h2>
+      <p>
+        We are happy to announce a publication of OSLC 3.0, the next generation of the core OSLC specification, as the
+        OASIS Standard. The specification in full can be viewed freely
+        <a href="https://docs.oasis-open-projects.org/oslc-op/core/v3.0/os/oslc-core.html">online</a> and this note will
+        serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the
+        specifications.
+      </p>
+      <p>
+        The OSLC Core 2.0 evolution from 1.0 strengthened its definition of the use of RESTful HTTP web services and
+        adopted an existing standard-based approach to representing a data model that was flexible and had multiple
+        representation formats, namely RDF. A primary goal of OSLC Core 3.0 was upwards compatibility with OSLC 2.0,
+        preserving the investment in existing implementations. Most OSLC Core 3.0 changes are optional and OSLC 2.0
+        servers will not be mandated to adopt them to be compliant with 3.0. In most cases, existing OSLC 2.0 clients
+        should be able to consume OSLC 3.0 servers with no changes. This should result in a less disruptive change from
+        2.0 to 3.0. This document provides a summary of the changes in OSLC Core 3.0 with respect to OSLC Core 2.0.
+      </p>
+      <p>
+        From the standardization point of view, there have been two major changes in OSLC 3.0 that further the openness
+        of OSLC and strengthen its integration value. First, the specification development was moved to OASIS, a
+        vendor-neutral standardization body with a proven track record of assisting in the publication of standards that
+        are widely adopted and further standardized by international bodies like ISO (e.g. <a
+          href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html"
+          >MQTT</a
+        >, <a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=office">ODF (ISO/IEC 26300-1:2015)</a>).
+        Throughout the development of the specifications, our member section at OASIS featured as many as
+        <a href="https://web.archive.org/web/20170814105435/http://www.oasis-oslc.org:80/members">16 members</a> before
+        executing a transition to an Open Project that has drastically lowered the bar to
+        <a href="https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md">entry</a>. Second, the OSLC 3.0
+        specification is now aligned with the <a href="https://www.w3.org/TR/ldp/">Linked Data Platform 1.0</a>, a W3C
+        Recommendation, that was adopted by projects such as <a href="https://solidproject.org/">Solid</a>, focused on
+        decentralizing data storage and spearheaded by Sir Tim Berners-Lee, the founding father of the Web.
+      </p>
     </section>
     <section id="resource-representations" class="level2">
-    <h2>Resource representations</h2>
-    <p>OSLC Core 2.0 mandates support for RDF/XML (<code>application/rdf+xml</code>) and made support for other RDF formats optional. OSLC Core 3.0 requires that servers support at least one RDF format, and recommends servers support RDF/XML, Turtle (<code>text/turtle</code>), and JSON-LD (<code>application/ld+json</code>), and use standard HTTP content negotiation in choosing which RDF format to return. Turtle is the preferred format used for examples in OSLC 3.0 specifications. Clients that specify both RDF/XML and Turtle formats in an <code>Accept</code> request header are likely to operate with both OSLC 2.0 and 3.0 servers without change. New clients that <em>only</em> accept Turtle might not work with older OSLC 2.0 servers that might only support RDF/XML.</p>
+      <h2>Resource representations</h2>
+      <p>
+        OSLC Core 2.0 mandates support for RDF/XML (<code>application/rdf+xml</code>) and made support for other RDF
+        formats optional. OSLC Core 3.0 requires that servers support at least one RDF format, and recommends servers
+        support RDF/XML, Turtle (<code>text/turtle</code>), and JSON-LD (<code>application/ld+json</code>), and use
+        standard HTTP content negotiation in choosing which RDF format to return. Turtle is the preferred format used
+        for examples in OSLC 3.0 specifications. Clients that specify both RDF/XML and Turtle formats in an
+        <code>Accept</code> request header are likely to operate with both OSLC 2.0 and 3.0 servers without change. New
+        clients that <em>only</em> accept Turtle might not work with older OSLC 2.0 servers that might only support
+        RDF/XML.
+      </p>
     </section>
     <section id="oslc-discovery" class="level2">
-    <h2>OSLC Discovery</h2>
-    <p>The discovery mechanisms defined in OSLC Core 2.0 for discovering OSLC service provider catalogs, service providers, services, creation factories, selection dialogs, and query capabilities continue to be supported in OSLC Core 3.0. If new OSLC 3.0 server implementations continue to support these discovery mechanisms, they should be consumable by existing OSLC 2.0 clients.</p>
-    <p>OSLC Core 3.0 extends OSLC 2.0 Discovery to allow servers to optionally support the use of OPTIONS and <code>Link</code> headers as an alternative mechanism to discover creation factories, selection dialogs, and resource preview. OSLC Core 3.0 further specifies well-known URIs registered with accordance to the <a href="https://datatracker.ietf.org/doc/html/rfc8615">RFC 8615</a> for probing the existence of OSLC Service Provider Catalogs as well as Jazz RootServices documents at well-known URIs.</p>
+      <h2>OSLC Discovery</h2>
+      <p>
+        The discovery mechanisms defined in OSLC Core 2.0 for discovering OSLC service provider catalogs, service
+        providers, services, creation factories, selection dialogs, and query capabilities continue to be supported in
+        OSLC Core 3.0. If new OSLC 3.0 server implementations continue to support these discovery mechanisms, they
+        should be consumable by existing OSLC 2.0 clients.
+      </p>
+      <p>
+        OSLC Core 3.0 extends OSLC 2.0 Discovery to allow servers to optionally support the use of OPTIONS and
+        <code>Link</code> headers as an alternative mechanism to discover creation factories, selection dialogs, and
+        resource preview. OSLC Core 3.0 further specifies well-known URIs registered with accordance to the
+        <a href="https://datatracker.ietf.org/doc/html/rfc8615">RFC 8615</a> for probing the existence of OSLC Service
+        Provider Catalogs as well as Jazz RootServices documents at well-known URIs.
+      </p>
     </section>
     <section id="creation-factories" class="level2">
-    <h2>Creation factories</h2>
-    <p>Creation factories in OSLC Core 3.0 are upwards compatible with Core 2.0 and existing OSLC 2.0 clients should be able to consume creation factories in an OSLC 3.0 server.</p>
+      <h2>Creation factories</h2>
+      <p>
+        Creation factories in OSLC Core 3.0 are upwards compatible with Core 2.0 and existing OSLC 2.0 clients should be
+        able to consume creation factories in an OSLC 3.0 server.
+      </p>
     </section>
     <section id="delegated-dialogs" class="level2">
-    <h2>Delegated dialogs</h2>
-    <p>OSLC Core 3.0 continues to support the use of delegated dialogs for creation and/or selection, and existing OSLC 2.0 clients should be able to consume these without change where these are declared in OSLC services.</p>
+      <h2>Delegated dialogs</h2>
+      <p>
+        OSLC Core 3.0 continues to support the use of delegated dialogs for creation and/or selection, and existing OSLC
+        2.0 clients should be able to consume these without change where these are declared in OSLC services.
+      </p>
     </section>
     <section id="query-capabilities" class="level2">
-    <h2>Query capabilities</h2>
-    <p>In OSLC Core 2.0, the use of query capabilities was defined by a section on discovery and a separate document on query syntax. In OSLC Core 3.0, there is a separate OSLC Query 3.0 specification that covers usage and query syntax, and describes the changes from, and compatibility with, query in OSLC Core 2.0. OSLC 2.0 clients should be able to consume query capabilities in an OSLC 3.0 server without change.</p>
+      <h2>Query capabilities</h2>
+      <p>
+        In OSLC Core 2.0, the use of query capabilities was defined by a section on discovery and a separate document on
+        query syntax. In OSLC Core 3.0, there is a separate OSLC Query 3.0 specification that covers usage and query
+        syntax, and describes the changes from, and compatibility with, query in OSLC Core 2.0. OSLC 2.0 clients should
+        be able to consume query capabilities in an OSLC 3.0 server without change.
+      </p>
     </section>
     <section id="prefixes" class="level2">
-    <h2>Prefixes</h2>
-    <p>OSLC Core 2.0 did not define a minimum set of prefixes that OSLC servers should predefine and declare in services. OSLC Core 3.0 defines a set of recommended predefined prefixes. Existing servers are not required to implement this to be compliant with OSLC Core 3.0, but it is recommended they do so for convenience to clients.</p>
+      <h2>Prefixes</h2>
+      <p>
+        OSLC Core 2.0 did not define a minimum set of prefixes that OSLC servers should predefine and declare in
+        services. OSLC Core 3.0 defines a set of recommended predefined prefixes. Existing servers are not required to
+        implement this to be compliant with OSLC Core 3.0, but it is recommended they do so for convenience to clients.
+      </p>
     </section>
     <section id="resource-paging" class="level2">
-    <h2>Resource Paging</h2>
-    <p>Resource paging is unchanged in OSLC Core 3.0 with respect to Core 2.0.</p>
+      <h2>Resource Paging</h2>
+      <p>Resource paging is unchanged in OSLC Core 3.0 with respect to Core 2.0.</p>
     </section>
     <section id="resource-preview" class="level2">
-    <h2>Resource preview</h2>
-    <p>In OSLC Core 2.0, clients can request a compact representation of a resource using <code>Accept=application/x-oslc-compact+xml</code>. This continues to be supported in OSLC Core 3.0. OSLC 3.0 servers that support this functionality will work with OSLC 2.0 clients.</p>
-    <p>OSLC Core 3.0 also supports a new way of discovering and consuming compact data for resource preview. An OSLC 3.0 server can include a <code>Link</code> header where the link relation is <code>http://open-services.net/ns/core#Compact</code> and the target URI is the URI of a compact resource. This also supports getting a compact representation in JSON. OSLC 2.0 clients won’t be aware of the new <code>Link</code> header and hence will not be impacted by this change.</p>
+      <h2>Resource preview</h2>
+      <p>
+        In OSLC Core 2.0, clients can request a compact representation of a resource using
+        <code>Accept=application/x-oslc-compact+xml</code>. This continues to be supported in OSLC Core 3.0. OSLC 3.0
+        servers that support this functionality will work with OSLC 2.0 clients.
+      </p>
+      <p>
+        OSLC Core 3.0 also supports a new way of discovering and consuming compact data for resource preview. An OSLC
+        3.0 server can include a <code>Link</code> header where the link relation is
+        <code>http://open-services.net/ns/core#Compact</code> and the target URI is the URI of a compact resource. This
+        also supports getting a compact representation in JSON. OSLC 2.0 clients won’t be aware of the new
+        <code>Link</code> header and hence will not be impacted by this change.
+      </p>
     </section>
     <section id="shapes-and-vocabularies" class="level2">
-    <h2>Shapes and vocabularies</h2>
-    <p>Resource shapes in OSLC Core 3.0 are upwards compatible with those defined in OSLC Core 2.0. Core 3.0 supports some additional optional constraints that include: 1. On a resource shape, <code>oslc:hidden</code> may be used to indicate the type should be hidden. Some OSLC 2.0 servers may have implemented this prior to its inclusion in OSLC Core 3.0. 2. On a property, <code>oslc:queryable</code> may be used to indicate whether a property is queryable and can be specified in an <code>oslc.where</code> query expression.</p>
-    <p>OSLC Core 3.0 provides separately fetchable files for resource shapes defined in the specification. These may be fetched as RDF (in RDF/XML or Turtle formats) or as rendered HTML using standard HTTP content negotiation. The OSLC Core 3.0 vocabulary and constraints multi-part specification documents are generated from these RDF ResourceShape constraint representations.</p>
+      <h2>Shapes and vocabularies</h2>
+      <p>
+        Resource shapes in OSLC Core 3.0 are upwards compatible with those defined in OSLC Core 2.0. Core 3.0 supports
+        some additional optional constraints that include: 1. On a resource shape, <code>oslc:hidden</code> may be used
+        to indicate the type should be hidden. Some OSLC 2.0 servers may have implemented this prior to its inclusion in
+        OSLC Core 3.0. 2. On a property, <code>oslc:queryable</code> may be used to indicate whether a property is
+        queryable and can be specified in an <code>oslc.where</code> query expression.
+      </p>
+      <p>
+        OSLC Core 3.0 provides separately fetchable files for resource shapes defined in the specification. These may be
+        fetched as RDF (in RDF/XML or Turtle formats) or as rendered HTML using standard HTTP content negotiation. The
+        OSLC Core 3.0 vocabulary and constraints multi-part specification documents are generated from these RDF
+        ResourceShape constraint representations.
+      </p>
     </section>
     <section id="authentication" class="level2">
-    <h2>Authentication</h2>
-    <p>OSLC Core 2.0 supports the use of HTTP Basic Authentication, OAuth (1.0), or both. OSLC Core 3.0 recommends that servers support OAuth 2.0 and OpenIdConnect, and only support HTTP Basic Authentication via SSL. Existing clients that support none of these may be unable to use an OSLC 3.0 server.</p>
+      <h2>Authentication</h2>
+      <p>
+        OSLC Core 2.0 supports the use of HTTP Basic Authentication, OAuth (1.0), or both. OSLC Core 3.0 recommends that
+        servers support OAuth 2.0 and OpenIdConnect, and only support HTTP Basic Authentication via SSL. Existing
+        clients that support none of these may be unable to use an OSLC 3.0 server.
+      </p>
     </section>
     <section id="cors-protocol" class="level2">
-    <h2>CORS protocol</h2>
-    <p>OSLC Core 2.0 did not address the issue of new security constraints being imposed by some web browsers to limit the loading of resources with cross-origin. See <a href="https://%5Bhttps://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-origin resource sharing</a>. An example is where a dialog served by one application embeds content from another application, such as in an iFrame. OSLC Core 3.0 recommends that servers support the CORS protocol to address these emerging security requirements.</p>
+      <h2>CORS protocol</h2>
+      <p>
+        OSLC Core 2.0 did not address the issue of new security constraints being imposed by some web browsers to limit
+        the loading of resources with cross-origin. See
+        <a href="https://%5Bhttps://en.wikipedia.org/wiki/Cross-origin_resource_sharing"
+          >Cross-origin resource sharing</a
+        >. An example is where a dialog served by one application embeds content from another application, such as in an
+        iFrame. OSLC Core 3.0 recommends that servers support the CORS protocol to address these emerging security
+        requirements.
+      </p>
     </section>
   </body>
 </html>

--- a/notes/core-3.0-changes/core-3.0-changes.html
+++ b/notes/core-3.0-changes/core-3.0-changes.html
@@ -1,12 +1,9 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
   <head>
-    <title>Summary of changes in OSLC Core 3.0</title>
+    <title>OSLC Core v3.0 Changes Version 1.0</title>
     <meta charset="utf-8" />
-    <meta
-      name="description"
-      content="This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications."
-    />
+    <meta name="description" content="This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications." />
 
     <!-- <script
       src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
@@ -17,14 +14,15 @@
     <script class="remove">
       var respecConfig = {
         shortName: "core-3.0-changes",
+        citationLabel: "OSLC-Core-Changes-v1.0",
         specStatus: "PN",
         revision: "01",
-        publishDate: "2021-11-04T18:00Z",
+        publishDate: "2021-12-16T18:00Z",
         // previousPublishDate: "2019-11-14",
         // previousMaturity: "PSD",
 
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
-        thisVersion: "https://docs.oasis-open-projects.org/oslc-op//notes/core-3.0-changes/pn01/core-3.0-changes.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/core-3.0-changes/v1.0/pn01/core-3.0-changes.html",
         // prevVersion: null,
         // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
         // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
@@ -32,7 +30,14 @@
         // Other parts of multi-part spec
         additionalArtifacts: [],
 
-        relatedWork: [],
+        relatedWork: [
+          {
+            title: "OSLC Core Version 3.0. Part 1: Overview",
+            href: "https://docs.oasis-open-projects.org/oslc-op/core/v3.0/os/oslc-core.html",
+            status: "Edited by Jim Amsden and Andrii Berezovskyi. 26 August 2021. OASIS Standard",
+            publisher: "OASIS",
+          },
+        ],
 
         localBiblio: {
           OSLCCore3: {
@@ -65,7 +70,6 @@
             licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
           },
         ],
-        citationLabel: "OSLC-CCM-30-Primer",
         maxTocLevel: 3,
         conformanceLabelPrefix: "QM",
         // noConformanceStyling: 1,
@@ -124,164 +128,64 @@
 
   <body>
     <section id="abstract">
-      <p>
-        This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes
-        in the specifications.
-      </p>
+      <p>This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications.</p>
     </section>
 
     <section id="toc"></section>
     <section id="sotd"></section>
 
     <section id="introduction" class="level2">
-      <h2>Introduction</h2>
-      <p>
-        We are happy to announce a publication of OSLC 3.0, the next generation of the core OSLC specification, as the
-        OASIS Standard. The specification in full can be viewed freely
-        <a href="https://docs.oasis-open-projects.org/oslc-op/core/v3.0/os/oslc-core.html">online</a> and this note will
-        serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the
-        specifications.
-      </p>
-      <p>
-        The OSLC Core 2.0 evolution from 1.0 strengthened its definition of the use of RESTful HTTP web services and
-        adopted an existing standard-based approach to representing a data model that was flexible and had multiple
-        representation formats, namely RDF. A primary goal of OSLC Core 3.0 was upwards compatibility with OSLC 2.0,
-        preserving the investment in existing implementations. Most OSLC Core 3.0 changes are optional and OSLC 2.0
-        servers will not be mandated to adopt them to be compliant with 3.0. In most cases, existing OSLC 2.0 clients
-        should be able to consume OSLC 3.0 servers with no changes. This should result in a less disruptive change from
-        2.0 to 3.0. This document provides a summary of the changes in OSLC Core 3.0 with respect to OSLC Core 2.0.
-      </p>
-      <p>
-        From the standardization point of view, there have been two major changes in OSLC 3.0 that further the openness
-        of OSLC and strengthen its integration value. First, the specification development was moved to OASIS, a
-        vendor-neutral standardization body with a proven track record of assisting in the publication of standards that
-        are widely adopted and further standardized by international bodies like ISO (e.g. <a
-          href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html"
-          >MQTT</a
-        >, <a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=office">ODF (ISO/IEC 26300-1:2015)</a>).
-        Throughout the development of the specifications, our member section at OASIS featured as many as
-        <a href="https://web.archive.org/web/20170814105435/http://www.oasis-oslc.org:80/members">16 members</a> before
-        executing a transition to an Open Project that has drastically lowered the bar to
-        <a href="https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md">entry</a>. Second, the OSLC 3.0
-        specification is now aligned with the <a href="https://www.w3.org/TR/ldp/">Linked Data Platform 1.0</a>, a W3C
-        Recommendation, that was adopted by projects such as <a href="https://solidproject.org/">Solid</a>, focused on
-        decentralizing data storage and spearheaded by Sir Tim Berners-Lee, the founding father of the Web.
-      </p>
+    <h2>Introduction</h2>
+    <p>We are happy to announce a publication of OSLC 3.0, the next generation of the core OSLC specification, as the OASIS Standard. The specification in full can be viewed freely <a href="https://docs.oasis-open-projects.org/oslc-op/core/v3.0/os/oslc-core.html">online</a> and this note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications.</p>
+    <p>The OSLC Core 2.0 evolution from 1.0 strengthened its definition of the use of RESTful HTTP web services and adopted an existing standard-based approach to representing a data model that was flexible and had multiple representation formats, namely RDF. A primary goal of OSLC Core 3.0 was upwards compatibility with OSLC 2.0, preserving the investment in existing implementations. Most OSLC Core 3.0 changes are optional and OSLC 2.0 servers will not be mandated to adopt them to be compliant with 3.0. In most cases, existing OSLC 2.0 clients should be able to consume OSLC 3.0 servers with no changes. This should result in a less disruptive change from 2.0 to 3.0. This document provides a summary of the changes in OSLC Core 3.0 with respect to OSLC Core 2.0.</p>
+    <p>From the standardization point of view, there have been two major changes in OSLC 3.0 that further the openness of OSLC and strengthen its integration value. First, the specification development was moved to OASIS, a vendor-neutral standardization body with a proven track record of assisting in the publication of standards that are widely adopted and further standardized by international bodies like ISO (e.g. <a href="https://docs.oasis-open.org/mqtt/mqtt/v5.0/mqtt-v5.0.html">MQTT</a>, <a href="https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=office">ODF (ISO/IEC 26300-1:2015)</a>). Throughout the development of the specifications, our member section at OASIS featured as many as <a href="https://web.archive.org/web/20170814105435/http://www.oasis-oslc.org:80/members">16 members</a> before executing a transition to an Open Project that has drastically lowered the bar to <a href="https://github.com/oslc-op/oslc-admin/blob/master/CONTRIBUTING.md">entry</a>. Second, the OSLC 3.0 specification is now aligned with the <a href="https://www.w3.org/TR/ldp/">Linked Data Platform 1.0</a>, a W3C Recommendation, that was adopted by projects such as <a href="https://solidproject.org/">Solid</a>, focused on decentralizing data storage and spearheaded by Sir Tim Berners-Lee, the founding father of the Web.</p>
     </section>
     <section id="resource-representations" class="level2">
-      <h2>Resource representations</h2>
-      <p>
-        OSLC Core 2.0 mandates support for RDF/XML (<code>application/rdf+xml</code>) and made support for other RDF
-        formats optional. OSLC Core 3.0 requires that servers support at least one RDF format, and recommends servers
-        support RDF/XML, Turtle (<code>text/turtle</code>), and JSON-LD (<code>application/ld+json</code>), and use
-        standard HTTP content negotiation in choosing which RDF format to return. Turtle is the preferred format used
-        for examples in OSLC 3.0 specifications. Clients that specify both RDF/XML and Turtle formats in an
-        <code>Accept</code> request header are likely to operate with both OSLC 2.0 and 3.0 servers without change. New
-        clients that <em>only</em> accept Turtle might not work with older OSLC 2.0 servers that might only support
-        RDF/XML.
-      </p>
+    <h2>Resource representations</h2>
+    <p>OSLC Core 2.0 mandates support for RDF/XML (<code>application/rdf+xml</code>) and made support for other RDF formats optional. OSLC Core 3.0 requires that servers support at least one RDF format, and recommends servers support RDF/XML, Turtle (<code>text/turtle</code>), and JSON-LD (<code>application/ld+json</code>), and use standard HTTP content negotiation in choosing which RDF format to return. Turtle is the preferred format used for examples in OSLC 3.0 specifications. Clients that specify both RDF/XML and Turtle formats in an <code>Accept</code> request header are likely to operate with both OSLC 2.0 and 3.0 servers without change. New clients that <em>only</em> accept Turtle might not work with older OSLC 2.0 servers that might only support RDF/XML.</p>
     </section>
     <section id="oslc-discovery" class="level2">
-      <h2>OSLC Discovery</h2>
-      <p>
-        The discovery mechanisms defined in OSLC Core 2.0 for discovering OSLC service provider catalogs, service
-        providers, services, creation factories, selection dialogs, and query capabilities continue to be supported in
-        OSLC Core 3.0. If new OSLC 3.0 server implementations continue to support these discovery mechanisms, they
-        should be consumable by existing OSLC 2.0 clients.
-      </p>
-      <p>
-        OSLC Core 3.0 extends OSLC 2.0 Discovery to allow servers to optionally support the use of OPTIONS and
-        <code>Link</code> headers as an alternative mechanism to discover creation factories, selection dialogs, and
-        resource preview. OSLC Core 3.0 further specifies well-known URIs registered with accordance to the
-        <a href="https://datatracker.ietf.org/doc/html/rfc8615">RFC 8615</a> for probing the existence of OSLC Service
-        Provider Catalogs as well as Jazz RootServices documents at well-known URIs.
-      </p>
+    <h2>OSLC Discovery</h2>
+    <p>The discovery mechanisms defined in OSLC Core 2.0 for discovering OSLC service provider catalogs, service providers, services, creation factories, selection dialogs, and query capabilities continue to be supported in OSLC Core 3.0. If new OSLC 3.0 server implementations continue to support these discovery mechanisms, they should be consumable by existing OSLC 2.0 clients.</p>
+    <p>OSLC Core 3.0 extends OSLC 2.0 Discovery to allow servers to optionally support the use of OPTIONS and <code>Link</code> headers as an alternative mechanism to discover creation factories, selection dialogs, and resource preview. OSLC Core 3.0 further specifies well-known URIs registered with accordance to the <a href="https://datatracker.ietf.org/doc/html/rfc8615">RFC 8615</a> for probing the existence of OSLC Service Provider Catalogs as well as Jazz RootServices documents at well-known URIs.</p>
     </section>
     <section id="creation-factories" class="level2">
-      <h2>Creation factories</h2>
-      <p>
-        Creation factories in OSLC Core 3.0 are upwards compatible with Core 2.0 and existing OSLC 2.0 clients should be
-        able to consume creation factories in an OSLC 3.0 server.
-      </p>
+    <h2>Creation factories</h2>
+    <p>Creation factories in OSLC Core 3.0 are upwards compatible with Core 2.0 and existing OSLC 2.0 clients should be able to consume creation factories in an OSLC 3.0 server.</p>
     </section>
     <section id="delegated-dialogs" class="level2">
-      <h2>Delegated dialogs</h2>
-      <p>
-        OSLC Core 3.0 continues to support the use of delegated dialogs for creation and/or selection, and existing OSLC
-        2.0 clients should be able to consume these without change where these are declared in OSLC services.
-      </p>
+    <h2>Delegated dialogs</h2>
+    <p>OSLC Core 3.0 continues to support the use of delegated dialogs for creation and/or selection, and existing OSLC 2.0 clients should be able to consume these without change where these are declared in OSLC services.</p>
     </section>
     <section id="query-capabilities" class="level2">
-      <h2>Query capabilities</h2>
-      <p>
-        In OSLC Core 2.0, the use of query capabilities was defined by a section on discovery and a separate document on
-        query syntax. In OSLC Core 3.0, there is a separate OSLC Query 3.0 specification that covers usage and query
-        syntax, and describes the changes from, and compatibility with, query in OSLC Core 2.0. OSLC 2.0 clients should
-        be able to consume query capabilities in an OSLC 3.0 server without change.
-      </p>
+    <h2>Query capabilities</h2>
+    <p>In OSLC Core 2.0, the use of query capabilities was defined by a section on discovery and a separate document on query syntax. In OSLC Core 3.0, there is a separate OSLC Query 3.0 specification that covers usage and query syntax, and describes the changes from, and compatibility with, query in OSLC Core 2.0. OSLC 2.0 clients should be able to consume query capabilities in an OSLC 3.0 server without change.</p>
     </section>
     <section id="prefixes" class="level2">
-      <h2>Prefixes</h2>
-      <p>
-        OSLC Core 2.0 did not define a minimum set of prefixes that OSLC servers should predefine and declare in
-        services. OSLC Core 3.0 defines a set of recommended predefined prefixes. Existing servers are not required to
-        implement this to be compliant with OSLC Core 3.0, but it is recommended they do so for convenience to clients.
-      </p>
+    <h2>Prefixes</h2>
+    <p>OSLC Core 2.0 did not define a minimum set of prefixes that OSLC servers should predefine and declare in services. OSLC Core 3.0 defines a set of recommended predefined prefixes. Existing servers are not required to implement this to be compliant with OSLC Core 3.0, but it is recommended they do so for convenience to clients.</p>
     </section>
     <section id="resource-paging" class="level2">
-      <h2>Resource Paging</h2>
-      <p>Resource paging is unchanged in OSLC Core 3.0 with respect to Core 2.0.</p>
+    <h2>Resource Paging</h2>
+    <p>Resource paging is unchanged in OSLC Core 3.0 with respect to Core 2.0.</p>
     </section>
     <section id="resource-preview" class="level2">
-      <h2>Resource preview</h2>
-      <p>
-        In OSLC Core 2.0, clients can request a compact representation of a resource using
-        <code>Accept=application/x-oslc-compact+xml</code>. This continues to be supported in OSLC Core 3.0. OSLC 3.0
-        servers that support this functionality will work with OSLC 2.0 clients.
-      </p>
-      <p>
-        OSLC Core 3.0 also supports a new way of discovering and consuming compact data for resource preview. An OSLC
-        3.0 server can include a <code>Link</code> header where the link relation is
-        <code>http://open-services.net/ns/core#Compact</code> and the target URI is the URI of a compact resource. This
-        also supports getting a compact representation in JSON. OSLC 2.0 clients won’t be aware of the new
-        <code>Link</code> header and hence will not be impacted by this change.
-      </p>
+    <h2>Resource preview</h2>
+    <p>In OSLC Core 2.0, clients can request a compact representation of a resource using <code>Accept=application/x-oslc-compact+xml</code>. This continues to be supported in OSLC Core 3.0. OSLC 3.0 servers that support this functionality will work with OSLC 2.0 clients.</p>
+    <p>OSLC Core 3.0 also supports a new way of discovering and consuming compact data for resource preview. An OSLC 3.0 server can include a <code>Link</code> header where the link relation is <code>http://open-services.net/ns/core#Compact</code> and the target URI is the URI of a compact resource. This also supports getting a compact representation in JSON. OSLC 2.0 clients won’t be aware of the new <code>Link</code> header and hence will not be impacted by this change.</p>
     </section>
     <section id="shapes-and-vocabularies" class="level2">
-      <h2>Shapes and vocabularies</h2>
-      <p>
-        Resource shapes in OSLC Core 3.0 are upwards compatible with those defined in OSLC Core 2.0. Core 3.0 supports
-        some additional optional constraints that include: 1. On a resource shape, <code>oslc:hidden</code> may be used
-        to indicate the type should be hidden. Some OSLC 2.0 servers may have implemented this prior to its inclusion in
-        OSLC Core 3.0. 2. On a property, <code>oslc:queryable</code> may be used to indicate whether a property is
-        queryable and can be specified in an <code>oslc.where</code> query expression.
-      </p>
-      <p>
-        OSLC Core 3.0 provides separately fetchable files for resource shapes defined in the specification. These may be
-        fetched as RDF (in RDF/XML or Turtle formats) or as rendered HTML using standard HTTP content negotiation. The
-        OSLC Core 3.0 vocabulary and constraints multi-part specification documents are generated from these RDF
-        ResourceShape constraint representations.
-      </p>
+    <h2>Shapes and vocabularies</h2>
+    <p>Resource shapes in OSLC Core 3.0 are upwards compatible with those defined in OSLC Core 2.0. Core 3.0 supports some additional optional constraints that include: 1. On a resource shape, <code>oslc:hidden</code> may be used to indicate the type should be hidden. Some OSLC 2.0 servers may have implemented this prior to its inclusion in OSLC Core 3.0. 2. On a property, <code>oslc:queryable</code> may be used to indicate whether a property is queryable and can be specified in an <code>oslc.where</code> query expression.</p>
+    <p>OSLC Core 3.0 provides separately fetchable files for resource shapes defined in the specification. These may be fetched as RDF (in RDF/XML or Turtle formats) or as rendered HTML using standard HTTP content negotiation. The OSLC Core 3.0 vocabulary and constraints multi-part specification documents are generated from these RDF ResourceShape constraint representations.</p>
     </section>
     <section id="authentication" class="level2">
-      <h2>Authentication</h2>
-      <p>
-        OSLC Core 2.0 supports the use of HTTP Basic Authentication, OAuth (1.0), or both. OSLC Core 3.0 recommends that
-        servers support OAuth 2.0 and OpenIdConnect, and only support HTTP Basic Authentication via SSL. Existing
-        clients that support none of these may be unable to use an OSLC 3.0 server.
-      </p>
+    <h2>Authentication</h2>
+    <p>OSLC Core 2.0 supports the use of HTTP Basic Authentication, OAuth (1.0), or both. OSLC Core 3.0 recommends that servers support OAuth 2.0 and OpenIdConnect, and only support HTTP Basic Authentication via SSL. Existing clients that support none of these may be unable to use an OSLC 3.0 server.</p>
     </section>
     <section id="cors-protocol" class="level2">
-      <h2>CORS protocol</h2>
-      <p>
-        OSLC Core 2.0 did not address the issue of new security constraints being imposed by some web browsers to limit
-        the loading of resources with cross-origin. See
-        <a href="https://%5Bhttps://en.wikipedia.org/wiki/Cross-origin_resource_sharing"
-          >Cross-origin resource sharing</a
-        >. An example is where a dialog served by one application embeds content from another application, such as in an
-        iFrame. OSLC Core 3.0 recommends that servers support the CORS protocol to address these emerging security
-        requirements.
-      </p>
+    <h2>CORS protocol</h2>
+    <p>OSLC Core 2.0 did not address the issue of new security constraints being imposed by some web browsers to limit the loading of resources with cross-origin. See <a href="https://%5Bhttps://en.wikipedia.org/wiki/Cross-origin_resource_sharing">Cross-origin resource sharing</a>. An example is where a dialog served by one application embeds content from another application, such as in an iFrame. OSLC Core 3.0 recommends that servers support the CORS protocol to address these emerging security requirements.</p>
     </section>
   </body>
 </html>

--- a/notes/core-3.0-changes/core-3.0-changes.html
+++ b/notes/core-3.0-changes/core-3.0-changes.html
@@ -5,26 +5,26 @@
     <meta charset="utf-8" />
     <meta name="description" content="This note will serve as a guide for existing OSLC 2.0 users to learn what’s new and navigate around the changes in the specifications." />
 
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.min.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
       async
       class="remove"
-    ></script>
-    <!-- <script src='http://127.0.0.1:8081/respec-oasis-common.js' async class='remove'></script> -->
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
         shortName: "core-3.0-changes",
-        specStatus: "PND",
+        specStatus: "PN",
         revision: "01",
-        publishDate: "2021-09-16",
+        publishDate: "2021-11-04T18:00Z",
         // previousPublishDate: "2019-11-14",
         // previousMaturity: "PSD",
 
-        thisVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
+        edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op//notes/core-3.0-changes/pn01/core-3.0-changes.html",
         // prevVersion: null,
         // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
         // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
-        edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
 
         // Other parts of multi-part spec
         additionalArtifacts: [],
@@ -34,24 +34,21 @@
         localBiblio: {
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
             authors: ["Jim Amsden", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCCoreVocab: {
             title: "OSLC Core Vocabulary",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
             authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCShapes: {
             title: "OSLC Resource Shape 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
             authors: ["Arthur Ryman", "Jim Amsden"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",

--- a/notes/core-3.0-changes/core-3.0-changes.md
+++ b/notes/core-3.0-changes/core-3.0-changes.md
@@ -1,6 +1,6 @@
 ---
-title: Summary of changes in OSLC Core 3.0 
-abstract: 
+title: OSLC Core v3.0 Changes Version 1.0 
+abstract:
   This note will serve as a guide for existing OSLC 2.0 users to learn what's new and navigate around the changes in the specifications.
 ---
 
@@ -38,7 +38,7 @@ In OSLC Core 2.0, the use of query capabilities was defined by a section on disc
 
 OSLC Core 2.0 did not define a minimum set of prefixes that OSLC servers should predefine and declare in services. OSLC Core 3.0 defines a set of recommended predefined prefixes. Existing servers are not required to implement this to be compliant with OSLC Core 3.0, but it is recommended they do so for convenience to clients.
 
-## Resource Paging 
+## Resource Paging
 
 Resource paging is unchanged in OSLC Core 3.0 with respect to Core 2.0.
 

--- a/notes/core-3.0-changes/template.html
+++ b/notes/core-3.0-changes/template.html
@@ -14,14 +14,15 @@
     <script class="remove">
       var respecConfig = {
         shortName: "core-3.0-changes",
+        citationLabel: "OSLC-Core-Changes-v1.0",
         specStatus: "PN",
         revision: "01",
-        publishDate: "2021-11-04T18:00Z",
+        publishDate: "2021-12-16T18:00Z",
         // previousPublishDate: "2019-11-14",
         // previousMaturity: "PSD",
 
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
-        thisVersion: "https://docs.oasis-open-projects.org/oslc-op//notes/core-3.0-changes/pn01/core-3.0-changes.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/core-3.0-changes/v1.0/pn01/core-3.0-changes.html",
         // prevVersion: null,
         // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
         // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
@@ -29,7 +30,14 @@
         // Other parts of multi-part spec
         additionalArtifacts: [],
 
-        relatedWork: [],
+        relatedWork: [
+          {
+            title: "OSLC Core Version 3.0. Part 1: Overview",
+            href: "https://docs.oasis-open-projects.org/oslc-op/core/v3.0/os/oslc-core.html",
+            status: "Edited by Jim Amsden and Andrii Berezovskyi. 26 August 2021. OASIS Standard",
+            publisher: "OASIS",
+          },
+        ],
 
         localBiblio: {
           OSLCCore3: {
@@ -62,7 +70,6 @@
             licenseURI: "https://www.apache.org/licenses/LICENSE-2.0",
           },
         ],
-        citationLabel: "OSLC-CCM-30-Primer",
         maxTocLevel: 3,
         conformanceLabelPrefix: "QM",
         // noConformanceStyling: 1,

--- a/notes/core-3.0-changes/template.html
+++ b/notes/core-3.0-changes/template.html
@@ -5,26 +5,26 @@
     <meta charset="utf-8" />
     <meta name="description" content="$abstract$" />
 
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.min.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
       async
       class="remove"
-    ></script>
-    <!-- <script src='http://127.0.0.1:8081/respec-oasis-common.js' async class='remove'></script> -->
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
         shortName: "core-3.0-changes",
-        specStatus: "PND",
+        specStatus: "PN",
         revision: "01",
-        publishDate: "2021-09-16",
+        publishDate: "2021-11-04T18:00Z",
         // previousPublishDate: "2019-11-14",
         // previousMaturity: "PSD",
 
-        thisVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
+        edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op//notes/core-3.0-changes/pn01/core-3.0-changes.html",
         // prevVersion: null,
         // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
         // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
-        edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/core-3.0-changes/core-3.0-changes.html",
 
         // Other parts of multi-part spec
         additionalArtifacts: [],
@@ -34,24 +34,21 @@
         localBiblio: {
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
             authors: ["Jim Amsden", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCCoreVocab: {
             title: "OSLC Core Vocabulary",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
             authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCShapes: {
             title: "OSLC Resource Shape 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
             authors: ["Arthur Ryman", "Jim Amsden"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",

--- a/notes/link-guidance.html
+++ b/notes/link-guidance.html
@@ -3,32 +3,36 @@
 <head>
 <meta charset='utf-8'/>
 <title>OSLC Core Version 3.0: Link Guidance</title>
-<script
-src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.24/builds/respec-oasis-common.min.js"
+<!-- <script
+src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
 async
 class="remove"
-></script>
+></script> -->
+<script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
+
 <script class='remove'>
   var respecConfig = {
-      specStatus:           "PND", //PN Draft
+      shortName:            "link-guidance",
+      specStatus:           "PN", //PN Draft
+      revision: "01",
+      publishDate:  "2021-11-04T18:00Z",
+
       edDraftURI:           "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html",
-      thisVersion:          "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html",
-      latestVersion:        "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html",
+      thisVersion:          "https://docs.oasis-open-projects.org/oslc-op/notes/link-guidance/pn01/link-guidance.html",
+      // latestVersion:        "https://oslc-op.github.io/oslc-specs/notes/link-guidance.html",
 
       // the specification's short name, as in http://www.w3.org/TR/short-name/
-      shortName:            "OSLC Link Guidance 3.0",
-      revision: "02",
 
       // if your specification has a subtitle that goes below the main
       // formal title, define it here
       // subtitle   :  "an excellent document",
 
       // if you wish the publication date to be other than the last modification, set this
-      // publishDate:  "2009-08-06",
 
       // if the specification's copyright date is a range of years, specify
       // the start date here:
       // copyrightStart: "2005"
+      license: "cc-by-4",
 
       // if there is a previously published draft, uncomment this and set its YYYY-MM-DD date
       // and its maturity status
@@ -93,7 +97,6 @@ class="remove"
 </section>
 
 <section id='toc'></section>
-<hr/>
 
 <section id="RelationshipsinOSLC">
 

--- a/notes/trs-guidance/trs-guidance.html
+++ b/notes/trs-guidance/trs-guidance.html
@@ -3,18 +3,24 @@
   <meta charset="utf-8" />
   <head>
     <title>OSLC Tracked Resource Set Guidance</title>
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.js"
       async
       class="remove"
-    ></script>
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
+
     <script class="remove">
       var respecConfig = {
         shortName: "trs-guidance",
-        specStatus: "PND",
+        specStatus: "PN",
         revision: "01",
-        noConformanceTable: 1,
+        publishDate: "2021-11-04T18:00Z",
+
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/trs-guidance/trs-guidance.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/notes/link-guidance/pn01/link-guidance.html",
+
+        noConformanceTable: 1,
         maxTocLevel: 3,
         license: "cc-by-4",
         additionalLicenses: [
@@ -85,9 +91,8 @@
       <p class="ednote" title="TBD">
         <strong
           >Several current editors and project members feel many of the opinions expressed in the Guidance sections are
-          excessively strict or judgemental, and not appropriate for general guidance. This document needs considerable
-          editing and redaction before being published.</strong
-        >
+          excessively strict or judgemental, and not appropriate for general guidance.
+        </strong>
       </p>
     </section>
     <section id="toc"></section>
@@ -110,7 +115,6 @@
         in terms of the size of pages in the base or change log, how long base pages are kept, how long change events
         are kept, and the minimum period for which change events behind the latest base cutoff are kept.
       </p>
-      <p class="note">In the primer, include examples such as 7/14/21 days from current docs ...</p>
     </section>
     <section id="patch-motivation" class="informative">
       <h2>Motivation and Use Cases for Patch Events</h2>

--- a/notes/trs-primer/template.html
+++ b/notes/trs-primer/template.html
@@ -5,26 +5,24 @@
     <meta charset="utf-8" />
     <meta name="description" content="$abstract$" />
 
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.min.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
       async
       class="remove"
-    ></script>
-    <!-- <script src='http://127.0.0.1:8081/respec-oasis-common.js' async class='remove'></script> -->
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
-        shortName: "config-primer",
-        specStatus: "PND",
+        shortName: "trs-primer",
+        specStatus: "PN",
         revision: "01",
-        // publishDate: "2020-08-27",
-        // previousPublishDate: "2019-11-14",
-        // previousMaturity: "PSD",
+        publishDate: "2021-11-04T18:00Z",
 
-        thisVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        prevVersion: null,
-        latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/notes/config-primer/pn01/config-primer.html",
+        // prevVersion: null,
+        // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
 
         // Other parts of multi-part spec
         additionalArtifacts: [],
@@ -34,24 +32,21 @@
         localBiblio: {
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
             authors: ["Jim Amsden", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCCoreVocab: {
             title: "OSLC Core Vocabulary",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
             authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCShapes: {
             title: "OSLC Resource Shape 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
             authors: ["Arthur Ryman", "Jim Amsden"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",

--- a/notes/trs-primer/trs-primer.html
+++ b/notes/trs-primer/trs-primer.html
@@ -5,26 +5,24 @@
     <meta charset="utf-8" />
     <meta name="description" content="This primer serves as a guide to the concepts in the TRS specification, and through the use of simple examples, explains how a data provider might expose resources in a TRS and how a TRS client might consume a data provider’s TRS." />
 
-    <script
-      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.29/builds/respec-oasis-common.min.js"
+    <!-- <script
+      src="https://cdn.jsdelivr.net/gh/oasis-tcs/tab-respec@v2.1.30/builds/respec-oasis-common.min.js"
       async
       class="remove"
-    ></script>
-    <!-- <script src='http://127.0.0.1:8081/respec-oasis-common.js' async class='remove'></script> -->
+    ></script> -->
+    <script src="http://127.0.0.1:9000/respec-oasis-common.js" async class="remove"></script>
     <script class="remove">
       var respecConfig = {
-        shortName: "config-primer",
-        specStatus: "PND",
+        shortName: "trs-primer",
+        specStatus: "PN",
         revision: "01",
-        // publishDate: "2020-08-27",
-        // previousPublishDate: "2019-11-14",
-        // previousMaturity: "PSD",
+        publishDate: "2021-11-04T18:00Z",
 
-        thisVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        prevVersion: null,
-        latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
-        latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
         edDraftURI: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        thisVersion: "https://docs.oasis-open-projects.org/oslc-op/notes/config-primer/pn01/config-primer.html",
+        // prevVersion: null,
+        // latestVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
+        // latestSpecVersion: "https://oslc-op.github.io/oslc-specs/notes/config-primer/config-primer.html",
 
         // Other parts of multi-part spec
         additionalArtifacts: [],
@@ -34,24 +32,21 @@
         localBiblio: {
           OSLCCore3: {
             title: "OSLC Core 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part1-overview/oslc-core-v3.0-csprd03-part1-overview.html",
             authors: ["Jim Amsden", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCCoreVocab: {
             title: "OSLC Core Vocabulary",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part7-core-vocabulary/oslc-core-v3.0-csprd03-part7-core-vocabulary.html",
             authors: ["Jim Amsden", "S. Padgett", "S. Speicher"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",
           },
           OSLCShapes: {
             title: "OSLC Resource Shape 3.0",
-            href:
-              "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
+            href: "https://docs.oasis-open.org/oslc-core/oslc-core/v3.0/csprd03/part6-resource-shape/oslc-core-v3.0-csprd03-part6-resource-shape.html",
             authors: ["Arthur Ryman", "Jim Amsden"],
             status: "Committee Specification Public Review Draft",
             publisher: "OASIS",


### PR DESCRIPTION
Some changes were needed to ReSpec, we will need to uncomment CDN URI with v2.1.30 once it's released.

See https://github.com/oasis-tcs/tab-respec/pull/58 and the PGB list announcement.