### PR TITLE
[QM OS] Removed TestResult allowedValue

### DIFF
--- a/specs/qm/quality-management-shapes.ttl
+++ b/specs/qm/quality-management-shapes.ttl
@@ -237,7 +237,6 @@
         a                    oslc:ResourceShape ;
         oslc:describes       oslc_qm:TestResult ;
         oslc:property        [ a                        oslc:Property ;
-                               oslc:allowedValue        "com.ibm.rqm.execution.common.state.failed" , "com.ibm.rqm.execution.common.state.inconclusive" , "com.ibm.rqm.execution.common.state.passed" , "com.ibm.rqm.execution.common.state.deferred" , "com.ibm.rqm.execution.common.state.incomplete" , "com.ibm.rqm.execution.common.state.blocked" , "com.ibm.rqm.execution.common.state.part_blocked" , "com.ibm.rqm.execution.common.state.perm_failed" , "com.ibm.rqm.execution.common.state.error" ;
                                oslc:hidden              false ;
                                oslc:isMemberProperty    false ;
                                oslc:name                "status" ;


### PR DESCRIPTION
It contained unnecessary references to IBM specific constraints.